### PR TITLE
Bump govspeak to 1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'uglifier', '>= 1.3.0'
 
 gem 'unicorn', '4.8.2'
 
-gem 'govspeak'
+gem 'govspeak', '1.5.2'
 
 gem 'plek', '1.7.0'
 gem 'gds-api-adapters', '10.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,10 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govspeak (1.5.1)
+    govspeak (1.5.2)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
+      nokogiri (~> 1.5.10)
       sanitize (~> 2.0.3)
     govuk_frontend_toolkit (0.48.0)
       rails (>= 3.1.0)
@@ -140,7 +141,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   gds-api-adapters (= 10.11.0)
-  govspeak
+  govspeak (= 1.5.2)
   govuk_frontend_toolkit (= 0.48.0)
   jasmine-rails
   plek (= 1.7.0)


### PR DESCRIPTION
Fixes an issue where sentences ending, eg, "in section s248." would be treated as a step list and produce bad markup. See https://github.com/alphagov/govspeak/pull/21

As example of an affected section is EIM21834 in section EIM21604.
