### PR TITLE
Use port 3072 in startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3071
+bundle exec rails s -p 3072


### PR DESCRIPTION
It was incorrectly using port 3071 which is reserved for another app, `hmrc-manuals-api`.

See https://github.gds/gds/development/blob/master/Procfile#L66-L67
