### PR TITLE
Rename hmrc-manuals-frontend to manuals-frontend

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,6 @@ module HmrcManualsFrontend
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.assets.prefix = '/hmrc-manuals-frontend'
+    config.assets.prefix = '/manuals-frontend'
   end
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,7 +3,7 @@ set -x
 export DISPLAY=:99
 export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
-export REPO_NAME="alphagov/hmrc-manuals-frontend"
+export REPO_NAME="alphagov/manuals-frontend"
 env
 
 function github_status {

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -7,13 +7,13 @@ namespace :router do
   end
 
   task :register_backend => :router_environment do
-    @router_api.add_backend('hmrc-manuals-frontend', Plek.current.find('hmrc-manuals-frontend', :force_http => true) + "/")
+    @router_api.add_backend('manuals-frontend', Plek.current.find('manuals-frontend', :force_http => true) + "/")
   end
 
   task :register_routes => :router_environment do
-    @router_api.add_route('/guidance/employment-income-manual', 'prefix', 'hmrc-manuals-frontend')
+    @router_api.add_route('/guidance/employment-income-manual', 'prefix', 'manuals-frontend')
   end
 
-  desc 'Register hmrc-manuals-frontend application and routes with the router'
+  desc 'Register manuals-frontend application and routes with the router'
   task :register => [ :register_backend, :register_routes ]
 end


### PR DESCRIPTION
Without this deployment fails because the Router data and the assets prefix won't agree with what's now in Puppet.

TODO as separate pull request: rename the main Rails object.

cc @alicebartlett @tommyp 
