### PR TITLE
Rename Rails Object to ManualsFrontend

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-HmrcManualsFrontend::Application.load_tasks
+ManualsFrontend::Application.load_tasks

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module HmrcManualsFrontend
+module ManualsFrontend
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
-HmrcManualsFrontend::Application.initialize!
+ManualsFrontend::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-HmrcManualsFrontend::Application.configure do
+ManualsFrontend::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-HmrcManualsFrontend::Application.configure do
+ManualsFrontend::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-HmrcManualsFrontend::Application.configure do
+ManualsFrontend::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,4 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-HmrcManualsFrontend::Application.config.secret_key_base = '4cb9f970cfd12120dd031a6ad68f10ba090ba8bdd03fbb259f042041daa404eff5caa87e441f6eef74624d57e9da999cd615066b970029081928f6db44f586d7'
+ManualsFrontend::Application.config.secret_key_base = '4cb9f970cfd12120dd031a6ad68f10ba090ba8bdd03fbb259f042041daa404eff5caa87e441f6eef74624d57e9da999cd615066b970029081928f6db44f586d7'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-HmrcManualsFrontend::Application.config.session_store :cookie_store, key: '_hmrc-manuals-frontend_session'
+ManualsFrontend::Application.config.session_store :cookie_store, key: '_hmrc-manuals-frontend_session'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-HmrcManualsFrontend::Application.routes.draw do
+ManualsFrontend::Application.routes.draw do
 
   get '/guidance/employment-income-manual', to: 'manuals#index'
   get '/guidance/employment-income-manual/:section_id', to: 'manuals#show'


### PR DESCRIPTION
As part of the renaming of this App, this commit removes `Hmrc` from the name of the Rails Object.

Part of https://trello.com/c/c6kTjaZ9/99-manuals-view-a-manual-5
