### PR TITLE
Prevent Google from crawling Manuals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,16 @@ class ApplicationController < ActionController::Base
 
   before_filter :slimmer_headers
 
+  before_filter :set_robots_headers
+
   private
 
   def slimmer_headers
     set_slimmer_headers(template: "header_footer_only")
+  end
+
+  def set_robots_headers
+    response.headers["X-Robots-Tag"] = "none"
   end
 
 end


### PR DESCRIPTION
During development, we want to exlude Google from crawling until we make the manuals public.

Relates to https://trello.com/c/wtCTzva1/106-block-hmrc-manuals-from-google-1
