### PR TITLE
Fix for immigration placeholder manual 404ing

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -12,6 +12,7 @@ namespace :router do
 
   task :register_routes => :router_environment do
     @router_api.add_route('/guidance/employment-income-manual', 'prefix', 'manuals-frontend')
+    @router_api.add_route('/guidance/immigration', 'prefix', 'manuals-frontend')
   end
 
   desc 'Register manuals-frontend application and routes with the router'


### PR DESCRIPTION
Without an updated_at date, the immigration manual was causing a 404.
