### PR TITLE
Update metadata label to match Whitehall

### DIFF
--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -5,14 +5,12 @@
     <% end %>
 
     <h1><%= @manual.title %></h1>
-    <dl>
-      <% if @manual.organisations.any? %>
-        <dt>Published by</dt>
-        <dd>
-          <%= links_to_sentence(@manual.organisations) %>
-        </dd>
-      <% end %>
-    </dl>
+    <% if @manual.organisations.any? %>
+      <dl>
+        <dt>From</dt>
+        <dd><%= links_to_sentence(@manual.organisations) %></dd>
+      </dl>
+    <% end %>
   </div>
   <div class='secondary'>
     <div class='secondary-inner'>


### PR DESCRIPTION
Whitehall has been updated to simplify metadata into "From", "History" and "Part of" groups. Organisations are in the "From" group. See https://github.com/alphagov/whitehall/pull/1519 for more context.

Also move the conditional to wrap the whole metadata block.
