### PR TITLE
Add web_url to static manual organisation tags

### DIFF
--- a/public/employment-income-manual/index.json
+++ b/public/employment-income-manual/index.json
@@ -6,6 +6,7 @@
     {
       "title": "HM Revenue & Customs",
       "slug": "hm-revenue-customs",
+      "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs",
       "details": {
         "type": "organisation"
       }


### PR DESCRIPTION
The app is now expecting this to be provided as part of the Content API response.
