### PR TITLE
Add redirect for /guidance

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -12,6 +12,7 @@ namespace :router do
 
   task :register_routes => :router_environment do
     @router_api.add_route('/guidance/employment-income-manual', 'prefix', 'manuals-frontend')
+    @router_api.add_redirect_route('/guidance', 'exact', '/government/publications?publication_filter_option=guidance', 'temporary')
   end
 
   desc 'Register manuals-frontend application and routes with the router'


### PR DESCRIPTION
Requests to www.gov.uk/guidance should respond with something other than a 404 in case people request it via URL hacking from a manual page.

Until we build a better option, the list of guidance publications published in Whitehall is the best we have.

Related to https://trello.com/c/0jDZiBik/134-hmrc-manual-and-manuals-deploy-manuals-frontend-to-production-2
