### PR TITLE
Don't rely on specific classes for subsections.

### DIFF
--- a/features/browsing-a-local-manual.feature
+++ b/features/browsing-a-local-manual.feature
@@ -4,7 +4,7 @@ Feature: Browsing a local manual
 
   Scenario: Viewing an existing manual
     When I view the employment income manual
-    And I click on the "EIM00500" subsection
+    And I click on "EIM00500"
     Then I should see "EIM00500 - Employment income"
 
   Scenario: Visiting a nonexistent document

--- a/features/step_definitions/manual_steps.rb
+++ b/features/step_definitions/manual_steps.rb
@@ -2,10 +2,8 @@ When(/^I view the employment income manual$/) do
   visit "/guidance/employment-income-manual"
 end
 
-When(/^I click on the "(.*?)" subsection$/) do |section|
-  within 'ol.section-links' do
-    click_on section
-  end
+When(/^I click on "(.*?)"$/) do |link_text|
+  click_on link_text
 end
 
 When(/^I visit a non\-existent employment income manual section$/) do


### PR DESCRIPTION
By genericising the cucumber feature to just 'click on <x>' rather than 'click on the <x> subsection' we don't lose any clarity, but we remove reliance on specific classes (i.e. the previous 'within' block to detect where on the page to click)

In a happy coincidence, there's only a single link on the employment income manuals page with "EIM00500" in it.
