### PR TITLE
Skip unnecessary js init if there are no sections

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -8,19 +8,22 @@
     this.$container = options.$el;
     this.markupSections();
     this.$sections = this.$container.find('.js-openable');
-    this.$sections.each($.proxy(this.initCollapsible, this));
 
-    this.$openAll = $("<a href='#' aria-hidden=true>Open all</a>"),
-    this.$closeAll = $("<a href='#' aria-hidden=true>Close all</a>");
-    this.addControls();
+    if(this.$sections.length > 0) {
+      this.$sections.each($.proxy(this.initCollapsible, this));
+      this.$openAll = $("<a href='#' aria-hidden=true>Open all</a>"),
+      this.$closeAll = $("<a href='#' aria-hidden=true>Close all</a>");
+      this.addControls();
 
-    this.closeAll();
+      this.closeAll();
 
-    var openSectionID = window.location.hash.substr(1);
-    if(typeof(this.collapsibles[openSectionID]) != 'undefined') {
-      this.collapsibles[openSectionID].open();
+      var openSectionID = window.location.hash.substr(1);
+      if(typeof(this.collapsibles[openSectionID]) != 'undefined') {
+        this.collapsibles[openSectionID].open();
+      }
     }
   }
+
 
   CollapsibleCollection.prototype.initCollapsible = function initCollapsible(sectionIndex){
     var $section = $(this.$sections[sectionIndex]);


### PR DESCRIPTION
Bypass js initialisation if the sectioncollection has only uncollapsible sections. This skip also includes skipping open all / close all links which don't do anything when there are no collapsibles.
