### PR TITLE
Add style for .legislative-list

### DIFF
--- a/app/assets/stylesheets/_govspeak.scss
+++ b/app/assets/stylesheets/_govspeak.scss
@@ -77,6 +77,14 @@
     }
   }
 
+  ol.legislative-list {
+    list-style: none;
+    margin-left: 0;
+    ol {
+      list-style: none;
+    }
+  }
+
   ul {
     list-style: disc;
     list-style-position: outside;


### PR DESCRIPTION
For lists that, semantically speaking, are ordered, but have contents that appear in legislation so must have user defined numbering systems.

![screen shot 2014-06-13 at 16 27 57](https://cloud.githubusercontent.com/assets/68009/3271691/6a697cf4-f30f-11e3-8e56-72f1a78ab59c.png)

Gist: https://gist.github.com/evilstreak/7097e6f0cd6b4a93d996
Trellos: 
https://trello.com/c/ZcadzeuM/127-manuals-add-multiple-levels-of-indentation-1
https://trello.com/c/lgFFfydK/59-manuals-alignment-for-manuals-disable-normal-list-markdown-3
