### PR TITLE
Fix /guidance redirect route

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -12,7 +12,7 @@ namespace :router do
 
   task :register_routes => :router_environment do
     @router_api.add_route('/guidance/employment-income-manual', 'prefix', 'manuals-frontend')
-    @router_api.add_redirect_route('/guidance', 'exact', '/government/publications?publication_filter_option=guidance', 'temporary')
+    @router_api.add_redirect_route('/guidance', 'exact', '/government/publications', 'temporary')
   end
 
   desc 'Register manuals-frontend application and routes with the router'


### PR DESCRIPTION
Routes containing a query string are not valid redirect targets for the Router API. The publications index is an even worse option than the pre-filtered list, but it's the best we have until we build a proper index page.
