### PR TITLE
Rename EIM index

### DIFF
--- a/public/employment-income-manual/index.json
+++ b/public/employment-income-manual/index.json
@@ -1,5 +1,5 @@
 {
-  "title": "Employment Income Manual: Main Contents",
+  "title": "Employment Income Manual",
   "updated_at": "2014-01-23T00:00:00+01:00",
   "web_url": "/guidance/employment-income-manual",
   "tags": [


### PR DESCRIPTION
When using the index to construct a fake manual the title was incorrectly being set as EIM Main Contents.

Fixes https://trello.com/c/NtXqndRX/143-employment-income-manual-title-is-now-employment-income-manual-main-contents
