### PR TITLE
Add CSS for making images stay inside container

### DIFF
--- a/app/assets/stylesheets/_govspeak.scss
+++ b/app/assets/stylesheets/_govspeak.scss
@@ -177,6 +177,12 @@
     }
   }
 
+  img {
+    width: auto;
+    height: auto;
+    max-width: $full-width;
+  }
+
   sup {
     font-size: 0.8em;
     line-height: 0.7em;


### PR DESCRIPTION
By uploading an attachment and prepending a bang to the embed code an Editor can embed images. This CSS keeps them inside of their container and resizes it down when smaller than desktop.
