### PR TITLE
Don't show title twice when showing manual contents

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,9 +151,13 @@
 
     .section-content {
       margin-top: $gutter-half;
-       @include media(tablet){
-         margin-top: $gutter;
-       }
+      @include media(tablet){
+        margin-top: $gutter;
+      }
+
+      .section-summary p {
+        @include core-24;
+      }
     }
   }
 

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, @manual.title %>
 <%= render partial: "header" %>
 <div class='manual-section'>
-  <h2 class='section-title'><span class='title'><%=@manual.title %></span></h2>
   <div class='section-content'>
-    <%= govspeak_to_html(@manual.body) %>
+    <div class='section-summary'>
+      <%= govspeak_to_html(@manual.body) %>
+    </div>
     <% @manual.section_groups.each do | group | %>
     <div class='js-collapsible-collection subsection-collection'>
       <div class='title-controls-wrap'>


### PR DESCRIPTION
([Trello ticket](https://trello.com/c/lPu0qn8v/259-bug-title-of-manuals-shouldn-t-be-repeated-on-contents-page-1))

Remove the redundant heading (it's displayed in the main bar at the top) and bump the size of the summary text to 24.

Before:
![before](https://dl.dropboxusercontent.com/u/39836361/Screenshot%202014-08-06%2014.18.48.png)

After:
![after](https://dl.dropboxusercontent.com/u/39836361/Screenshot%202014-08-06%2014.14.15.png)
