### PR TITLE
Tweak CSS so really long breadcrumbs wrap nicer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,25 +97,24 @@
   }
 
   .breadcrumb-trail {
+    @include core-16;
     margin:10px 0 0 0;
-    padding:0 0;
+    padding:0 0 10px;
     border-bottom: 1px solid $border-colour;
-    @extend %contain-floats;
 
     strong {
       font-weight:bold;
     }
 
     li {
-      @include core-16;
       background-image: image-url("separator.png");
       background-position: 100% 10%;
       background-repeat: no-repeat;
-      float: left;
+      display: inline;
       list-style: none;
       margin-left: 5px;
       margin-right: 5px;
-      padding: 0 20px 10px 0;
+      padding: 0 20px 0 0;
 
       @include media(tablet){
         background-position: 100% 28%;


### PR DESCRIPTION
Use display inline instead of floats so that manual sections with really long titles wrap nicely instead of acting as a block.
### Before

![screen shot 2014-08-08 at 11 31 37](https://cloud.githubusercontent.com/assets/74812/3855720/86cf30c2-1ee9-11e4-9e2f-26b1093f8bbf.png)
### After

![screen shot 2014-08-08 at 13 13 40](https://cloud.githubusercontent.com/assets/74812/3856355/78287306-1ef5-11e4-99f0-206c726df0ab.png)
