### PR TITLE
Handle footnotes in manual sections

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -21,6 +21,8 @@
       if(typeof(this.collapsibles[openSectionID]) != 'undefined') {
         this.collapsibles[openSectionID].open();
       }
+
+      this.$container.on('click', 'a[rel="footnote"]', $.proxy(this.expandFootnotes, this));
     }
   }
 
@@ -38,6 +40,10 @@
     this.collapsibles[sectionID] = collapsible;
   }
 
+  CollapsibleCollection.prototype.expandFootnotes = function expandFootnotes(){
+    this.collapsibles['footnotes'].open();
+  }
+
   CollapsibleCollection.prototype.markupSections = function markupSections(){
     // Pull out h2's and mark them up as js-subsection-title.
     // Mark all following tags up to the next h2 as js-subsection-body.
@@ -47,7 +53,12 @@
     var subsectionHeaders = this.$container.find('h2').not('.linked-title, .js-ignore-h2s h2');
     subsectionHeaders.addClass('js-subsection-title');
     subsectionHeaders.each(function(index){
-      var subsectionBody = $(this).nextUntil('h2.js-subsection-title, h2.linked-title');
+      var $subsectionHeader = $(this);
+      if ($subsectionHeader.attr('id') == "footnotes") {
+        $subsectionHeader.data('section-id', 'footnotes');
+      }
+
+      var subsectionBody = $subsectionHeader.nextUntil('h2.js-subsection-title, h2.linked-title');
       subsectionBody.andSelf().wrapAll('<div class="manual-subsection js-openable"></div>');
       subsectionBody.wrapAll('<div class="js-subsection-body"></div>');
     });

--- a/app/assets/stylesheets/_govspeak.scss
+++ b/app/assets/stylesheets/_govspeak.scss
@@ -186,7 +186,7 @@
   sup {
     font-size: 0.8em;
     line-height: 0.7em;
-    vertical-align: top;
+    vertical-align: super;
   }
 
   .information-block,

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -158,6 +158,11 @@
         @include core-24;
       }
     }
+
+    .footnotes {
+      border-top: 0;
+      padding-top: 0;
+    }
   }
 
   .collapsible-subsections h2 {


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/oiJYOedK/266-manuals-footnotes-frontend)

Manual sections containing footnotes now have an h2 added for the footnotes detail at the bottom of the body.

Style it appropriately.

When a user clicks on a footnote link, open the footnotes section so that the footnote content is visible.

(JavaScript with @alicebartlett)

This depends on https://github.com/alphagov/specialist-publisher/pull/217

Footnotes after this change in a manual (they weren't supported before this, so no point with an unstyled 'before')

![footnote](https://dl.dropboxusercontent.com/u/39836361/Screenshot%202014-08-11%2008.40.16.png)
