### PR TITLE
Fix line width for sections without <h2>

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -6,6 +6,7 @@
     this.collapsibles = {};
 
     this.$container = options.$el;
+    this.markupHeaderlessSection();
     this.markupSections();
     this.$sections = this.$container.find('.js-openable');
 
@@ -62,6 +63,15 @@
       subsectionBody.andSelf().wrapAll('<div class="manual-subsection js-openable"></div>');
       subsectionBody.wrapAll('<div class="js-subsection-body"></div>');
     });
+  }
+
+  CollapsibleCollection.prototype.markupHeaderlessSection = function markupHeaderlessSection(){
+    // Starting from the first tag in .govspeak, find all the tags until a .manual-subsection
+    // Wrap them in a js-section-body
+    // These will now have a class with the proper width declaration
+
+    var headerlessContent = this.$container.find('.govspeak').children().first().nextUntil('h2').andSelf();
+    headerlessContent.wrapAll('<div class="js-section-body"></div>');
   }
 
   CollapsibleCollection.prototype.closeAll = function closeAll(event){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -165,6 +165,12 @@
     }
   }
 
+  .js-section-body {
+    @include media(tablet) {
+      width:$two-thirds;
+    }
+  }
+
   .collapsible-subsections h2 {
     @include core-19;
     font-weight:bold;


### PR DESCRIPTION
When starting a document with something other than a `<h2>`, the body of the section was being incorrectly displayed as full width. This commit wraps everything in the body up until the first `<h2>` in a div allowing us to style it. [Ticket](https://trello.com/c/aUmow68N/267-bug-line-wrapping-on-manuals).
