### PR TITLE
Link to the API representation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <link rel="alternate" type="application/json" href="/api<%= request.path %>.json">
 </head>
 <body>
   <div id="global-breadcrumb" class="header-context"></div>


### PR DESCRIPTION
I found myself wanting this to get at the Content API format.

Additionally, the Service Manual suggests that we do it:
https://www.gov.uk/service-manual/making-software/apis.html#representations-are-for-the-consumer 
