### PR TITLE
Bump slimmer to 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.0.4'
-gem 'slimmer'
+gem 'slimmer', '~> 4.2.0'
 
 gem 'govuk_frontend_toolkit', '1.2.0'
 gem 'sass-rails', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0.4)
-    slimmer (4.1.0)
+    slimmer (4.2.0)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -230,7 +230,7 @@ DEPENDENCIES
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.2)
   selenium-webdriver (~> 2.42.0)
-  slimmer
+  slimmer (~> 4.2.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)
   webmock (~> 1.17.4)


### PR DESCRIPTION
In 4.1.1 we've swapped from loading test assets from preview to loading them from production. That should quieten down most of the intermittent test failures we're getting due to timeouts.
