### PR TITLE
Limit width of Manual and Document summaries

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -72,7 +72,7 @@
     // Wrap them in a js-section-body
     // These will now have a class with the proper width declaration
 
-    var headerlessContent = this.$container.find('.govspeak').children().first().nextUntil('h2').andSelf();
+    var headerlessContent = this.$container.find('.govspeak').children(':not(h2)').first().nextUntil('h2').andSelf();
     headerlessContent.wrapAll('<div class="js-section-body"></div>');
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -156,6 +156,9 @@
 
       .summary {
         @include core-24;
+        @include media(tablet) {
+          width:$two-thirds;
+        }
       }
     }
 


### PR DESCRIPTION
This commit limits the width of Manual and Document summaries in order to bring it in line with the rest of the body content in Documents.

This also fixes an issue with the bug fix for line width on content in the body. It does this by using the CSS not selector to go through all children except h2s, so it will never skip the first element in .govspeak, which might be a h2.
