### PR TITLE
Fix for collapsible sections width issue

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -68,12 +68,16 @@
   }
 
   CollapsibleCollection.prototype.markupHeaderlessSection = function markupHeaderlessSection(){
-    // Starting from the first tag in .govspeak, find all the tags until a .manual-subsection
-    // Wrap them in a js-section-body
-    // These will now have a class with the proper width declaration
+    // For a document that starts with content other than a h2
+    // starting at the first tag inside .govspeak of .collapsible-subsections
+    // find all tags that are children of .collapsible-subsections until the
+    // first h2 and wrap them in a js-section-body to make them the correct width
 
-    var headerlessContent = this.$container.find('.govspeak').children(':not(h2)').first().nextUntil('h2').andSelf();
-    headerlessContent.wrapAll('<div class="js-section-body"></div>');
+    var firstChild = this.$container.find('.collapsible-subsections > .govspeak').children().first();
+    if (!firstChild.is('h2')) {
+      var headerlessContent = firstChild.nextUntil('h2').andSelf();
+      headerlessContent.wrapAll('<div class="js-section-body"></div>');
+    };
   }
 
   CollapsibleCollection.prototype.closeAll = function closeAll(event){

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -9,14 +9,20 @@ describe('CollapsibleCollection', function(){
         '<div class="title-controls-wrap">'+
         '</div>'+
         '<div class="collapsible-subsections">'+
-          // Three collapsible subsections
-          '<h2 id="a-section-title">A section title!</h2>'+
-          '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
-          '<h2 id="a-second-section-title">A second section title!</h2>'+
-          '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
-          '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
-          '<h2 id="a-third-section-title">A third section title!</h2>'+
-          '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+          '<div class="govspeak">'+
+            // Some content not in a collapsible subsection
+            '<p>Where the tax gets paid to the man about the thing for the other thing</p>'+
+            '<p>Where the tax gets paid to the man about the thing for the other thing</p>'+
+            '<p>Where the tax gets paid to the man about the thing for the other thing</p>'+
+            // Three collapsible subsections
+            '<h2 id="a-section-title">A section title!</h2>'+
+            '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+            '<h2 id="a-second-section-title">A second section title!</h2>'+
+            '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+            '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+            '<h2 id="a-third-section-title">A third section title!</h2>'+
+            '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+          '</div>'+
         '</div>'+
       '</div>';
 
@@ -199,6 +205,12 @@ describe('CollapsibleCollection', function(){
       collectionsFromHRMCHTML.find('h2.js-subsection-title').each(function(index){
         expect($(this).next().hasClass('js-subsection-body')).toBe(true);
       });
+    });
+  });
+
+  describe('markupHeaderlessSection', function(){
+    it('should wrap a section that does not begin with a h2 with js-section-body', function() {
+      expect($('body .collapsible-subsections > .govspeak').find('.js-section-body').length).toBe(1);
     });
   });
 


### PR DESCRIPTION
With the fix introduced in [#68](https://github.com/alphagov/manuals-frontend/pull/68), there was an issue were it was finding the first element which wasn't a h2, when it should have been starting at the first element and doing nothing if it was a h2. This commit fixes that bug.
