### PR TITLE
Fix copy

### DIFF
--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -15,7 +15,7 @@
   <div class='secondary'>
     <div class='secondary-inner'>
       <p>
-        Manual updated: <%= marked_up_date(@manual.updated_at) %>
+        Updated: <%= marked_up_date(@manual.updated_at) %>
       </p>
       <% unless @manual.hmrc? %>
         <p>

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -36,7 +36,7 @@ module AppHelpers
 
   def expect_manual_update_date_to_be(date)
     within('header .secondary') do
-      expect(page).to have_content("Manual updated: #{date}")
+      expect(page).to have_content("Updated: #{date}")
     end
   end
 


### PR DESCRIPTION
Removed the word 'manual' because users find it confusing when they're looking at a document they don't think of as a manual, eg the Immigration Rules.
