### PR TITLE
Add and improve print stylesheets for manuals on gov.uk

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -1,0 +1,90 @@
+a {
+  text-decoration: none;
+}
+
+// hide all the things
+.alpha-label,
+.breadcrumb-trail,
+.title-controls-wrap {
+  display: none;
+}
+
+.primary {
+  h1 {
+    margin-bottom: 5px;
+  }
+
+  dl {
+    float: left;
+    margin-top: 0;
+    width: 25%;
+    dt,
+    dd {
+      display: block;
+    }
+    dd {
+      font-weight: bold;
+      margin-left: 0;
+      & a[href^="http://"]:after,
+      & a[href^="https://"]:after {
+          content: "";
+      }
+    }
+    dt:after {
+      content: ":";
+    }
+  }
+}
+
+#manuals-frontend header dt {
+  min-width: 0!important;
+}
+
+.secondary {
+  float: left;
+  margin-bottom: 20px;
+  width: 75%;
+
+  .secondary-inner {
+    p {
+      margin-top: 0;
+      & + p {
+        display: none;
+      }      
+    }
+
+    time {
+      font-weight: bold;
+      display: block;
+    }
+  }
+}
+
+.govspeak {
+  width: 75%;
+}
+
+.linked-title {
+  @include core-16;
+  width: 75%;
+   .subsection-title-text {
+     font-weight: bold;
+   }
+  .subsection-summary {
+    display: block;
+    font-weight: normal;
+  }
+  a[href^="/"]:after {
+   @include core-14;
+  }
+}
+
+.manual-subsection {
+  margin-bottom: 30px;
+
+  h2 {
+    @include core-16;
+    font-weight: bold;
+  }
+}
+

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,17 @@
+// PRINT STYLESHEET COMPILER
+
+// STYLEGUIDE
+// Mixins to be shared across gov.uk sites. Anything set in these
+// files can be used in the view files.
+
+$is-print: true;
+
+// From the https://github.com/alphagov/govuk_frontend_toolkit
+@import "_colours.scss";
+@import "_conditionals.scss";
+@import "_css3.scss";
+@import "_typography.scss";
+@import "_measurements.scss";
+
+@import "_manuals-print.scss";
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
+  <%= stylesheet_link_tag "print.css", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
• create print scss file to compile print styles
• add print styles for manuals -
  • remove unecessary page elements for print
  • reduce and rationalise font sizes and weights
  • remove underlines from link as they are unhelpful when printing
  • shorten line lengths to 75% page width for better reading
  • improve general spacing for clarity and ease of reading

![contents-page-after](https://cloud.githubusercontent.com/assets/1692222/4116959/59024a7a-328b-11e4-8ac1-29af5bd431ce.png)
![contents-page-before](https://cloud.githubusercontent.com/assets/1692222/4116957/58fc2bc2-328b-11e4-9522-f0120684e034.png)
![section-page-after](https://cloud.githubusercontent.com/assets/1692222/4116958/59015142-328b-11e4-856c-cdbc90848da2.png)
![section-page-before](https://cloud.githubusercontent.com/assets/1692222/4116956/58fbdc6c-328b-11e4-91ca-47c24f291c7d.png)
