### PR TITLE
Add display:block to html5 main tag

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,10 @@
 // TODO: Delete this once the EIM holding page is removed
 @import "eim_holding_page_style_overrides";
 
+main {
+  display:block;
+}
+
 .outer-block {
   @include outer-block;
 }


### PR DESCRIPTION
IE9/10 and 11 don't treat <main> tags as block level elements, so we need to add display:block to them so that they accept the outer-block width stylings rather than being full width.
