### PR TITLE
Use print.css when printing

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
-  <%= stylesheet_link_tag "print.css", media: "print" %>
+  <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
After the print stylesheet was added in 0111c5f it was being included with the `stylesheet_link_tag` helper as print.css. The helper then thought this was at the root and was including it as /print.css at the root of the domain. This commit removes the .css which allows the helper to function correctly.
