### PR TITLE
Precompile print.css in Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,7 @@ ManualsFrontend::Application.configure do
       application-ie6.css
       application-ie7.css
       application-ie8.css
+      print.css
     )
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
As print.css isn't precompiled by default, it needs added to the list of stylesheets to compile in the Production environment.
