### PR TITLE
Add js to auto open sections

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,12 +10,20 @@ jQuery(function($) {
     new GOVUK.CollapsibleCollection({$el:$(this)});
   })
 
+  if (window.location.hash) {
+    openSectionContainingAnchor($(window.location.hash));
+  }
+
   $('.govspeak').on('click', 'a', function(event){
     if (window.location.pathname == event.target.pathname) {
-      var $section = $(event.target.hash);
-      if ($section.length != 0) {
-        new GOVUK.Collapsible($section).open();
-      }
+      openSectionContainingAnchor($(window.location.hash));
     }
   })
 });
+
+
+function openSectionContainingAnchor($anchor) {
+  if ($anchor.length != 0) {
+    new GOVUK.Collapsible($anchor.closest('.js-openable')).open();
+  }
+}


### PR DESCRIPTION
In Specialist publisher we offer instruction for how to link to a paragraph elsewhere in the page or on another page. This works using anchors. This PR makes sure if a link is clicked going to a paragraph elsewhere on the page, that the containing section is opened, and if on page load the url contains an anchor then the containing section is also opened.
