### PR TITLE
Make all of list item clickable

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -152,7 +152,6 @@ main {
       list-style: none;
       cursor: pointer;
       border-top: 1px solid $border-colour;
-      padding: $gutter-one-third $gutter-one-third $gutter-one-third 0;
 
       &:hover {
         background-color:$grey-4;
@@ -164,9 +163,10 @@ main {
       a {
         text-decoration: none;
         display:block;
+        padding: $gutter-one-third $gutter-one-third $gutter-one-third 0;
 
         @include media(tablet){
-          max-width:$two-thirds;
+          padding-right:$one-third;
         }
 
         .subsection-title-text {


### PR DESCRIPTION
Currently although all of an index item on a manual looks like it's clickable actually only the text is.

This commit pushes the whitespace into the padding of the link tag so that the whole of the link area is clickable rather than just the two-thirds with text in.
