### PR TITLE
Unify shared styles

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -61,7 +61,7 @@
       }
 
       var subsectionBody = $subsectionHeader.nextUntil('h2.js-subsection-title');
-      subsectionBody.andSelf().wrapAll('<div class="manual-subsection js-openable"></div>');
+      subsectionBody.andSelf().wrapAll('<div class="js-openable"></div>');
       subsectionBody.wrapAll('<div class="js-subsection-body"></div>');
     });
   }

--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -50,7 +50,7 @@ a {
       margin-top: 0;
       & + p {
         display: none;
-      }      
+      }
     }
 
     time {
@@ -64,22 +64,7 @@ a {
   width: 75%;
 }
 
-.linked-title {
-  @include core-16;
-  width: 75%;
-   .subsection-title-text {
-     font-weight: bold;
-   }
-  .subsection-summary {
-    display: block;
-    font-weight: normal;
-  }
-  a[href^="/"]:after {
-   @include core-14;
-  }
-}
-
-.manual-subsection {
+.js-openable {
   margin-bottom: 30px;
 
   h2 {
@@ -87,4 +72,3 @@ a {
     font-weight: bold;
   }
 }
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -290,7 +290,7 @@ main {
     }
   }
 
-  .manual-subsection {
+  .js-openable {
     border-top: 1px solid $border-colour;
     padding-bottom: $gutter;
 

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -107,9 +107,9 @@ describe('CollapsibleCollection', function(){
       expect(html.find('h2.js-subsection-title').length).toBe(sectionHeaderCount);
     });
 
-    it('should wrap h2 and section in a div with the classes js-openable and manual-subsection for blobs', function(){
+    it('should wrap h2 and section in a div with the classes js-openable for blobs', function(){
       collectionsFromBlobHTML.find('h2.js-subsection-title').each(function(index){
-        expect($(this).parents('.js-openable.manual-subsection').length).toBe(1);
+        expect($(this).parents('.js-openable').length).toBe(1);
       });
     });
 

--- a/spec/javascripts/collapsible_spec.js
+++ b/spec/javascripts/collapsible_spec.js
@@ -3,7 +3,7 @@ describe('Collapsible', function(){
   var collapsible, collapsibleHTML;
 
   beforeEach(function(){
-    var collapsibleString = '<section class="manual-subsection closed" data-section-id="EIM11210">'+
+    var collapsibleString = '<section class="closed" data-section-id="EIM11210">'+
       '<div class="js-subsection-title">'+
         '<span class="subsection-id ">EIM11210</span>'+
         '<h4 id="EIM11210">'+


### PR DESCRIPTION
Just a little PR removing a bit more cruft from the Manuals-Frontend mainly:

Removing the class 'manual-subsection' from the codebase and putting all of that responsibility onto the class 'js-openable' which is a better name and also one that was already there.

Removing subsection summary styles which are also no longer used

Removing linked-title from the print stylesheet, which should have been removed sooner (in an earlier commit which removes it from the rest of the codebase)
