### PR TITLE
Remove breadcrumb link to contents on contents page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -138,6 +138,9 @@ main {
         background-image:none;
         color: $secondary-text-colour;
       }
+      &.no-separator {
+        background-image:none;
+      }
     }
   }
 

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -24,7 +24,12 @@
   </div>
 </header>
 <ol class='breadcrumb-trail' role='breadcrumbs'>
-  <li><%= link_to 'Contents', @manual.url %></li>
+  <% if request.path == @manual.url %>
+    <li class="no-separator">Contents</li>
+  <% else %>
+    <li><%= link_to 'Contents', @manual.url %></li>
+  <% end %>
+
   <% if @document %>
     <% @document.breadcrumbs.each do | crumb | %>
       <li> <%= link_to crumb.label, crumb.link %></li>


### PR DESCRIPTION
It’s confusing for users if we have a breadcrumb linking to the page they are currently on.
This PR removes the link when a user is on the Contents page. As shown:

![no-link](https://cloud.githubusercontent.com/assets/265403/4662912/bbb9b2ac-5536-11e4-94a4-fab12d7b8532.png)
