### PR TITLE
Apply standard GOV.UK breadcrumb styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -115,16 +115,16 @@ main {
 
     li {
       background-image: image-url("separator.png");
-      background-position: 100% 10%;
+      background-position: 100% 20%;
       background-repeat: no-repeat;
       display: inline;
       list-style: none;
-      margin-left: 5px;
+      margin-left: 0;
       margin-right: 5px;
-      padding: 0 20px 0 0;
+      padding: 0 15px 0 0;
 
       @include media(tablet){
-        background-position: 100% 28%;
+        background-position: 100% 45%;
       }
 
       @include device-pixel-ratio() {
@@ -136,10 +136,13 @@ main {
       }
       &.last-child {
         background-image:none;
-        color: $secondary-text-colour;
+        color: $text-colour;
       }
       &.no-separator {
         background-image:none;
+      }
+      a {
+        color: $text-colour;
       }
     }
   }

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -34,6 +34,6 @@
     <% @document.breadcrumbs.each do | crumb | %>
       <li> <%= link_to crumb.label, crumb.link %></li>
     <% end %>
-    <li class='last-child'><strong><%= @document.breadcrumb %></strong></li>
+    <li class='last-child'><%= @document.breadcrumb %></li>
   <% end %>
 </ol>


### PR DESCRIPTION
Makes sense for the manuals breadcrumbs to be consistent with the existing GOV.UK style elsewhere.
Compare the breadcrumbs here: https://www.gov.uk/types-of-school vs. here: https://www.gov.uk/guidance/content-design/what-is-content-design to see the current difference.

This PR changes the manual breadcrumb style to this: 

![man_bc](https://cloud.githubusercontent.com/assets/265403/4666272/f2af3c30-5551-11e4-91a7-96ddb3973859.png)
