### PR TITLE
Change ALPHA label to BETA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_filter :slimmer_headers
-  before_filter :set_alpha_header
+  before_filter :set_beta_header
   before_filter :set_robots_headers
 
   private
@@ -15,8 +15,8 @@ class ApplicationController < ActionController::Base
     set_slimmer_headers(template: "header_footer_only")
   end
 
-  def set_alpha_header
-    response.headers[Slimmer::Headers::ALPHA_LABEL] = "before:#manuals-frontend header"
+  def set_beta_header
+    response.headers[Slimmer::Headers::BETA_LABEL] = "before:#manuals-frontend header"
   end
 
   def set_robots_headers


### PR DESCRIPTION
Because for manuals published on GOV.UK, the content is accurate and complete.
A manual will now look like this:

![beta](https://cloud.githubusercontent.com/assets/265403/4666745/535d2a2a-5556-11e4-915b-4ca030564646.png)
