### PR TITLE
Include section group titles on manual index pages

### DIFF
--- a/app/views/manuals/_hmrc_sections.html.erb
+++ b/app/views/manuals/_hmrc_sections.html.erb
@@ -1,3 +1,6 @@
+<% if group.title %>
+  <%= group.title %>
+<% end %>
 <% group.sections.each do | section | %>
   <% if section.collapsible? %>
     <h2>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -17,9 +17,6 @@
   <% if @manual.hmrc? %>
     <div class='subsection-collection'>
       <% @document.section_groups.each do | group | %>
-        <% if group.title %>
-          <%= group.title %>
-        <% end %>
       <%= render 'hmrc_sections', :group => group %>
     <% end %>
     </div>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -35,6 +35,8 @@ feature "Viewing manuals and sections" do
 
     expect_section_title_to_be("Inheritance tax: table of contents")
 
+    expect_a_child_section_group_title_of("This is a dummy child_section_group title")
+
     expect_page_to_include_section("General",
                                    href: "/guidance/inheritance-tax-manual/eim00505")
     expect_page_to_include_section("Particular items: A to P",

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -52,6 +52,12 @@ module AppHelpers
     end
   end
 
+  def expect_a_child_section_group_title_of(child_section_group_title)
+    within('.subsection-collection') do
+      expect(page).to have_content(child_section_group_title)
+    end
+  end
+
   def expect_page_to_be_affiliated_with_org(options)
     expect(page).to have_link(options[:title],
                               "https://www.gov.uk/government/organisations/#{options[:slug]}")

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -106,7 +106,7 @@ module ManualHelpers
         section_id: "eim00500",
         child_section_groups: [
           {
-            title: nil,
+            title: "This is a dummy child_section_group title",
             child_sections: [
               {
                 section_id: "EIM00505",


### PR DESCRIPTION
Currently, if a section group on an HMRC manual page has a title, it isn't
included. Section groups on a section are, however. This commit fixes that.
