### PR TITLE
Fix display of breadcrumbs for sub sub sections

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -29,8 +29,8 @@ class DocumentPresenter
   def breadcrumbs
     crumbs = []
     if document['details']['breadcrumbs'].present?
-      crumbs = document['details']['breadcrumbs'][1..-2].map do | section_id |
-        OpenStruct.new(link: "#{manual.url}/#{section_id}", label: section_id)
+      crumbs = document['details']['breadcrumbs'].map do |breadcrumb|
+        OpenStruct.new(link: breadcrumb['base_path'], label: breadcrumb['section_id'])
       end
     else
       []

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -48,6 +48,18 @@ feature "Viewing manuals and sections" do
                                           slug: "hm-revenue-customs")
   end
 
+  scenario "viewing a sub-sub section" do
+    stub_hmrc_manual
+    stub_hmrc_manual_sub_sub_section
+
+    visit_manual_section "inheritance-tax-manual", "eim00501"
+
+    expect(page).to have_link("Contents",
+                              href: "/guidance/inheritance-tax-manual")
+    expect(page).to have_link("EIM00500",
+                              href: "/guidance/inheritance-tax-manual/eim00500")
+  end
+
   scenario "visiting a manual section with a body" do
     stub_hmrc_manual
     stub_hmrc_manual_section_with_body

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -127,6 +127,28 @@ module ManualHelpers
     content_store_has_item("/guidance/inheritance-tax-manual/eim00500", section_json)
   end
 
+  def stub_hmrc_manual_sub_sub_section
+    section_json = {
+      base_path: "/guidance/inheritance-tax-manual/eim00501",
+      title: "Inheritance tax: table of contents",
+      description: nil,
+      format: "manual-section",
+      public_updated_at: "2014-01-23T00:00:00+01:00",
+      details: {
+        breadcrumbs: [
+          {
+            section_id: "EIM00500",
+            base_path: "/guidance/inheritance-tax-manual/eim00500"
+          }
+        ],
+        body: "Some body to love",
+        section_id: "eim00501"
+      }
+    }
+
+    content_store_has_item("/guidance/inheritance-tax-manual/eim00501", section_json)
+  end
+
   def stub_hmrc_manual_section_with_body(manual_id="inheritance-tax-manual", section_id="eim15000",
                                          title="Parent-financed and non-approved retirement benefits schemes: table of contents")
     section_json = {


### PR DESCRIPTION
The format of breadcrumbs in the Content Store changed some time ago. There are
no longer elements to ignore and each item in the array is a hash, not a string
section ID.
