### PR TITLE
Fix Firefox bug

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -334,6 +334,8 @@ main {
         position:absolute;
         left:-9999px;
         width:100px;
+        height: 1px;
+        overflow: hidden;
       }
     }
   }


### PR DESCRIPTION
In Firefox the page length is calculated by the content even if that content is off the page (e.g. at a negative margin). This is different to the way all IE/Chrome do it and was only just spotted. Add 1px overflow hidden to the hidden sections so FF calculates the page height as we want and we don't get a really huge blank footer.
