### PR TITLE
Change the hmrc-manuals prefix to hmrc-internal-manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ run
 
 in a terminal.
 
-visit [http://localhost:3071/hmrc-manuals/employment-income-manual/EIMANUAL](http://localhost:3071/hmrc-manuals/employment-income-manual/EIMANUAL)
+visit [http://localhost:3071/hmrc-internal-manuals/employment-income-manual/EIMANUAL](http://localhost:3071/hmrc-internal-manuals/employment-income-manual/EIMANUAL)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
   <div id="wrapper">
-    <main id="content" role="main" class="hmrc-manuals-frontend-content outer-block">
+    <main id="content" role="main" class="hmrc-internal-manuals-frontend-content outer-block">
       <div id="manuals-frontend" class='inner-block'>
         <%= yield %>
       </div>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-ManualsFrontend::Application.config.session_store :cookie_store, key: '_hmrc-manuals-frontend_session'
+ManualsFrontend::Application.config.session_store :cookie_store, key: '_hmrc-internal-manuals-frontend_session'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 ManualsFrontend::Application.routes.draw do
-  with_options(constraints: { prefix: /(guidance|hmrc-manuals)/ }) do |r|
+  with_options(constraints: { prefix: /(guidance|hmrc-internal-manuals)/ }) do |r|
     r.get '/:prefix/:manual_id', to: 'manuals#index'
     r.get '/:prefix/:manual_id/updates', to: 'manuals#updates'
     r.get '/:prefix/:manual_id/:section_id', to: 'manuals#show'

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -22,7 +22,7 @@ feature "Viewing manuals and sections" do
     #   includes_text: "This manual is a guide to the Income Tax (Earnings and Pensions) Act")
 
     expect_page_to_include_section("Inheritance tax",
-                                   href: "/hmrc-manuals/inheritance-tax-manual/eim00500")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
 
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
@@ -40,13 +40,13 @@ feature "Viewing manuals and sections" do
     expect_a_child_section_group_title_of("This is a dummy child_section_group title")
 
     expect_page_to_include_section("General",
-                                   href: "/hmrc-manuals/inheritance-tax-manual/eim00505")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505")
     expect_page_to_include_section("Particular items: A to P",
-                                   href: "/hmrc-manuals/inheritance-tax-manual/eim01000")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000")
 
     # breadcrumb
     expect(page).to have_link("Contents",
-                              href: "/hmrc-manuals/inheritance-tax-manual")
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual")
 
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
@@ -59,9 +59,9 @@ feature "Viewing manuals and sections" do
     visit_hmrc_manual_section "inheritance-tax-manual", "eim00501"
 
     expect(page).to have_link("Contents",
-                              href: "/hmrc-manuals/inheritance-tax-manual")
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual")
     expect(page).to have_link("EIM00500",
-                              href: "/hmrc-manuals/inheritance-tax-manual/eim00500")
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
   end
 
   scenario "visiting a manual section with a body" do
@@ -80,7 +80,7 @@ feature "Viewing manuals and sections" do
 
     expect_page_to_include_section("EIM00100 About this manual")
     expect_page_to_include_section("EIM00500 Inheritance tax",
-                                   href: "/hmrc-manuals/inheritance-tax-manual/eim00500")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
   end
 
   scenario "navigating from the manual to a section" do
@@ -91,20 +91,20 @@ feature "Viewing manuals and sections" do
 
     select_section "Inheritance tax"
 
-    expect(current_path).to eq("/hmrc-manuals/inheritance-tax-manual/eim00500")
+    expect(current_path).to eq("/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
     expect_section_title_to_be("Inheritance tax")
   end
 
   scenario "visiting a non-existent section" do
     stub_hmrc_manual
-    content_store_does_not_have_item('/hmrc-manuals/inheritance-tax-manual/nonexistent-manual-section')
+    content_store_does_not_have_item('/hmrc-internal-manuals/inheritance-tax-manual/nonexistent-manual-section')
 
     visit_hmrc_manual_section "inheritance-tax-manual", "nonexistent-manual-section"
     expect(page.status_code).to eq(404)
   end
 
   scenario "visiting the obsolete prototype HMRC manual" do
-    content_store_does_not_have_item('/hmrc-manuals/employment-income-manual')
+    content_store_does_not_have_item('/hmrc-internal-manuals/employment-income-manual')
 
     visit_hmrc_manual "employment-income-manual"
     expect_manual_title_to_be("This prototype of the Employment Income Manual is no longer available")
@@ -112,8 +112,8 @@ feature "Viewing manuals and sections" do
   end
 
   scenario "visiting a section in the obsolete prototype HMRC manual" do
-    content_store_does_not_have_item('/hmrc-manuals/employment-income-manual')
-    content_store_does_not_have_item('/hmrc-manuals/employment-income-manual/abc123')
+    content_store_does_not_have_item('/hmrc-internal-manuals/employment-income-manual')
+    content_store_does_not_have_item('/hmrc-internal-manuals/employment-income-manual/abc123')
 
     visit_hmrc_manual_section "employment-income-manual", "abc123"
     expect_manual_title_to_be("This prototype of the Employment Income Manual is no longer available")

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -12,11 +12,11 @@ module AppHelpers
   end
 
   def visit_hmrc_manual(manual_slug)
-    visit "/hmrc-manuals/#{manual_slug}"
+    visit "/hmrc-internal-manuals/#{manual_slug}"
   end
 
   def visit_hmrc_manual_section(manual_slug, section_slug)
-    visit "/hmrc-manuals/#{manual_slug}/#{section_slug}"
+    visit "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}"
   end
 
   def select_section(section_title)

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -57,7 +57,7 @@ module ManualHelpers
 
   def stub_hmrc_manual(manual_id="inheritance-tax-manual", title="Inheritance Tax Manual")
     manual_json = {
-      base_path: "/hmrc-manuals/#{manual_id}",
+      base_path: "/hmrc-internal-manuals/#{manual_id}",
       title: title,
       description: nil,
       format: "manual",
@@ -69,12 +69,12 @@ module ManualHelpers
             child_sections: [
               {
                 section_id: "EIM00100",
-                base_path: "/hmrc-manuals/#{manual_id}/eim00100",
+                base_path: "/hmrc-internal-manuals/#{manual_id}/eim00100",
                 title: "About this manual",
               },
               {
                 section_id: "EIM00500",
-                base_path: "/hmrc-manuals/#{manual_id}/eim00500",
+                base_path: "/hmrc-internal-manuals/#{manual_id}/eim00500",
                 title: "Inheritance tax",
               },
             ]
@@ -91,12 +91,12 @@ module ManualHelpers
       }
     }
 
-    content_store_has_item("/hmrc-manuals/#{manual_id}", manual_json)
+    content_store_has_item("/hmrc-internal-manuals/#{manual_id}", manual_json)
   end
 
   def stub_hmrc_manual_section_with_subsections
     section_json = {
-      base_path: "/hmrc-manuals/inheritance-tax-manual/eim00500",
+      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500",
       title: "Inheritance tax: table of contents",
       description: nil,
       format: "manual-section",
@@ -110,12 +110,12 @@ module ManualHelpers
             child_sections: [
               {
                 section_id: "EIM00505",
-                base_path: "/hmrc-manuals/inheritance-tax-manual/eim00505",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505",
                 title: "General",
               },
               {
                 section_id: "EIM01000",
-                base_path: "/hmrc-manuals/inheritance-tax-manual/eim01000",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000",
                 title: "Particular items: A to P",
               },
             ]
@@ -124,12 +124,12 @@ module ManualHelpers
       }
     }
 
-    content_store_has_item("/hmrc-manuals/inheritance-tax-manual/eim00500", section_json)
+    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00500", section_json)
   end
 
   def stub_hmrc_manual_sub_sub_section
     section_json = {
-      base_path: "/hmrc-manuals/inheritance-tax-manual/eim00501",
+      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00501",
       title: "Inheritance tax: table of contents",
       description: nil,
       format: "manual-section",
@@ -138,7 +138,7 @@ module ManualHelpers
         breadcrumbs: [
           {
             section_id: "EIM00500",
-            base_path: "/hmrc-manuals/inheritance-tax-manual/eim00500"
+            base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500"
           }
         ],
         body: "Some body to love",
@@ -146,25 +146,25 @@ module ManualHelpers
       }
     }
 
-    content_store_has_item("/hmrc-manuals/inheritance-tax-manual/eim00501", section_json)
+    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00501", section_json)
   end
 
   def stub_hmrc_manual_section_with_body(manual_id="inheritance-tax-manual", section_id="eim15000",
                                          title="Parent-financed and non-approved retirement benefits schemes: table of contents")
     section_json = {
-      base_path: "/hmrc-manuals/#{manual_id}/#{section_id}",
+      base_path: "/hmrc-internal-manuals/#{manual_id}/#{section_id}",
       title: title,
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
       details: {
-        body: 'On this page:<br><br><a href="/hmrc-manuals/#{manual_id}/#{section_id}#EIM15010#IDAZR1YH">Sections 386-400 ITEPA 2003]</a><br>',
+        body: 'On this page:<br><br><a href="/hmrc-internal-manuals/#{manual_id}/#{section_id}#EIM15010#IDAZR1YH">Sections 386-400 ITEPA 2003]</a><br>',
         section_id: "#{section_id}",
         child_section_groups: []
       }
     }
 
-    content_store_has_item("/hmrc-manuals/#{manual_id}/#{section_id}", section_json)
+    content_store_has_item("/hmrc-internal-manuals/#{manual_id}/#{section_id}", section_json)
   end
 end
 


### PR DESCRIPTION
- These manuals aren't normal manuals, they're internal manuals
  published solely because of FoI requests. End users should therefore
  be made aware that they're different (and in a different style, etc.)
  hence this change.

This is related to https://github.com/alphagov/hmrc-manuals-api/pull/82.
