### PR TITLE
Change BETA banner for HMRC manuals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,18 +5,15 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  include Slimmer::SharedTemplates
+
   before_filter :slimmer_headers
-  before_filter :set_beta_header
   before_filter :set_robots_headers
 
   private
 
   def slimmer_headers
     set_slimmer_headers(template: "header_footer_only")
-  end
-
-  def set_beta_header
-    response.headers[Slimmer::Headers::BETA_LABEL] = "before:#manuals-frontend header"
   end
 
   def set_robots_headers

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -5,6 +5,21 @@ class ManualPresenter
     @manual = manual
   end
 
+  def beta?
+    # At some point some of the manuals will be in beta and some won't and we'll need to
+    # check that here and return true/fase accordingly. Punting that work into the future
+    # for now as I don't have time to do it before the Show The Thing deadline in two day's
+    # time.
+
+    true
+  end
+
+  def beta_message
+    if hmrc?
+      "This part of GOV.UK is still being built – you can <a href='http://www.hmrc.gov.uk/thelibrary/manuals.htm'>access the manuals from HMRC</a> in the meantime"
+    end
+  end
+
   def full_title
     if hmrc?
       @manual.title + ' - HMRC Manuals'

--- a/app/views/manuals/_beta_label.html.erb
+++ b/app/views/manuals/_beta_label.html.erb
@@ -1,0 +1,5 @@
+<% if manual.beta_message %>
+  <%= render partial: 'govuk_component/beta_label', locals: { message: manual.beta_message } %>
+<% else %>
+  <%= render partial: 'govuk_component/beta_label' %>
+<% end %>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,7 +1,10 @@
+<% if @manual.beta? %>
+  <%= render partial: 'beta_label', locals: { manual: @manual } %>
+<% end %>
 <header class="<%= @manual.hmrc? ? 'hmrc' : nil %>">
   <div class='primary'>
     <% if @manual.hmrc? %>
-      <span class='manual-type'>HMRC manuals</span>
+      <span class='manual-type'>HMRC internal manuals</span>
     <% end %>
 
     <h1><%= @manual.title %></h1>


### PR DESCRIPTION
- Removed Slimmer beta label
- Added Slimmer template
- Included govuk_component template
- Added handling for different Beta Labels for HMRC and non HMRC manuals

Removed slimmer settings for beta banner and added in handling for different manuals (hmrc and non hmrc) to have different banner text

Trello ticket: https://trello.com/c/Z2z8wKgh/432-hmrc-manuals-frontend-3
