### PR TITLE
Remove bottom border from beta banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,10 @@ main {
 #manuals-frontend {
   padding-bottom:$gutter*3;
 
+  .govuk-beta-label {
+    border-bottom: none;
+  }
+
   header {
     background: $govuk-blue;
     &.hmrc {


### PR DESCRIPTION
The Beta banner has a grey 1px border which sits against the blue/green header in the manuals. As it is only 1px it makes the border look fuzzy so I'm removing it.

Before:
![screen shot 2014-12-09 at 14 33 08](https://cloud.githubusercontent.com/assets/68009/5358834/5847a432-7fb0-11e4-9eb4-812c2114ab53.png)

After:
![screen shot 2014-12-09 at 14 32 48](https://cloud.githubusercontent.com/assets/68009/5358836/5cd45be4-7fb0-11e4-8e3b-800364d855be.png)
