### PR TITLE
Disable sessions/don't set a session cookie

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-ManualsFrontend::Application.config.session_store :cookie_store, key: '_hmrc-internal-manuals-frontend_session'
+ManualsFrontend::Application.config.session_store :disabled


### PR DESCRIPTION
As I understand it, our frontend apps don't use sessions and, except for
Licensing, they are stripped off requests and responses by our Varnish
configuration in puppet.

So this should make dev more like production and avoid accidentally introducing
a dependency on sessions.

If we are being consistent, we should apply this to all of our frontend apps.
