### PR TITLE
Enable pages to be used in iframes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,10 @@ module ManualsFrontend
     # config.i18n.default_locale = :de
 
     config.assets.prefix = '/manuals-frontend'
+
+    # Override Rails 4 default which restricts framing to SAMEORIGIN.
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'ALLOWALL'
+    }
   end
 end


### PR DESCRIPTION
Rails 4+ sets the X-Frame-Options header to SAMEORIGIN by default. This means
that the resource can only be put into an iframe on the same domain.

One problem this causes is that the side-by-side browser - which is a tool used
during transition - can't work correctly.

In the past we have decided that, with the exception of transaction start
pages, we want to allow content on GOV.UK to be iframed. Transaction start
pages are exceptional because we are particularly concerned about clickjacking
of the start button.
