### PR TITLE
Remove HTML only used by the JavaScript

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -121,7 +121,7 @@
 
     // The Updates pages have a title for each collapsible section (they're sorted by year), include this if it's there
     var $title = this.$container.find($('.section-title'));
-    if ($title == []) {
+    if ($title.length) {
       $collectionControlsWrap.prepend($title);
     }
 

--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -114,9 +114,18 @@
   }
 
   CollapsibleCollection.prototype.addControls = function addControls(){
+    var $collectionControlsWrap = $('<div class="js-title-controls-wrap"/>');
     var $collectionControls = $('<div class="js-collection-controls" />');
     $collectionControls.append(this.$openAll, this.$closeAll);
-    this.$container.find('.title-controls-wrap').append($collectionControls);
+    $collectionControlsWrap.append($collectionControls);
+
+    // The Updates pages have a title for each collapsible section (they're sorted by year), include this if it's there
+    var $title = this.$container.find($('.section-title'));
+    if ($title == []) {
+      $collectionControlsWrap.prepend($title);
+    }
+
+    this.$container.prepend($collectionControlsWrap);
     this.$openAll.on('click', this.openAll.bind(this));
     this.$closeAll.on('click', this.closeAll.bind(this));
   }

--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -4,8 +4,7 @@ a {
 
 // hide all the things
 .alpha-label,
-.breadcrumb-trail,
-.title-controls-wrap {
+.breadcrumb-trail {
   display: none;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -249,10 +249,10 @@ main {
       margin-top: $gutter;
     }
 
-    .title-controls-wrap {
+    .js-title-controls-wrap {
       @extend %contain-floats;
 
-      .title {
+      .section-title {
         @include heading-24;
         @include media(tablet) {
           float:left;

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -20,8 +20,6 @@
     <% else %>
       <% if @document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= @document.collapse_depth %>>
-          <div class='title-controls-wrap'>
-          </div>
           <div class='collapsible-subsections'>
             <div class='govspeak'>
               <%= @document.body %>

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -6,9 +6,7 @@
     <div class='section-content'>
     <% @manual.change_notes.by_year.each do |year, updates_by_year| %>
       <div class='js-collapsible-collection subsection-collection'>
-        <div class='title-controls-wrap'>
-          <p class='title'><%= year %></p>
-        </div>
+        <p class='section-title'><%= year %></p>
         <div class='collapsible-subsections'>
           <% updates_by_year.each do |day, updated_documents| %>
             <h2>

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -6,8 +6,6 @@ describe('CollapsibleCollection', function(){
     // Content comes as a single blob of markdown from the GDSAPI in the "body" field.
     collectionsFromBlobString =
       '<div class="js-collapsible-collection subsection-collection">'+
-        '<div class="title-controls-wrap">'+
-        '</div>'+
         '<div class="collapsible-subsections">'+
           '<div class="govspeak">'+
             // Some content not in a collapsible subsection


### PR DESCRIPTION
The `<div class="title-controls-wrap">` us only used if the JavaScript has loaded -its part of the controls used for the collapsible sections.

This PR removes this HTML from the templates and adds the JavaScript to build it after document.ready. This means if the JS hasn't loaded for whatever we don't have bits of HTML floating around that aren't used.

