### PR TITLE
"HMRC internal manuals" => "HMRC internal manual"

### DIFF
--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -22,7 +22,7 @@ class ManualPresenter
 
   def full_title
     if hmrc?
-      @manual.title + ' - HMRC internal manuals'
+      @manual.title + ' - HMRC internal manual'
     else
       @manual.title + ' - Guidance'
     end

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -4,7 +4,7 @@
 <header aria-labelledby="manual-title" class="<%= @manual.hmrc? ? 'hmrc' : nil %>">
   <div class='primary'>
     <% if @manual.hmrc? %>
-      <span class='manual-type'>HMRC internal manuals</span>
+      <span class='manual-type'>HMRC internal manual</span>
     <% end %>
 
     <h1 id="manual-title"><%= @manual.title %></h1>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -12,7 +12,7 @@ feature "Viewing manuals and sections" do
 
     visit_hmrc_manual "inheritance-tax-manual"
 
-    expect_title_tag_to_be('Inheritance Tax Manual - HMRC internal manuals - GOV.UK')
+    expect_title_tag_to_be('Inheritance Tax Manual - HMRC internal manual - GOV.UK')
     expect_manual_title_to_be("Inheritance Tax Manual")
     expect_manual_update_date_to_be("23 January 2014")
 
@@ -34,7 +34,7 @@ feature "Viewing manuals and sections" do
 
     visit_hmrc_manual_section "inheritance-tax-manual", "eim00500"
 
-    expect_title_tag_to_be('EIM00500 - Inheritance Tax Manual - HMRC internal manuals - GOV.UK')
+    expect_title_tag_to_be('EIM00500 - Inheritance Tax Manual - HMRC internal manual - GOV.UK')
     expect_section_title_to_be("Inheritance tax: table of contents")
 
     expect_a_child_section_group_title_of("This is a dummy child_section_group title")

--- a/spec/features/viewing_manual_updates_spec.rb
+++ b/spec/features/viewing_manual_updates_spec.rb
@@ -20,7 +20,7 @@ feature "Viewing updates for a manual" do
 
     visit_hmrc_manual "inheritance-tax-manual"
     view_manual_change_notes
-    expect_title_tag_to_be('Updates - Inheritance Tax Manual - HMRC internal manuals - GOV.UK')
+    expect_title_tag_to_be('Updates - Inheritance Tax Manual - HMRC internal manual - GOV.UK')
   end
 
   scenario "viewing change notes for a specific date", js: true do


### PR DESCRIPTION
Using the singular fits the pattern of lots of other things, particularly in
Whitehall. This change was prompted by HMRC.