### PR TITLE
[DISCUSS - DO NOT MERGE] Add page navigation to hmrc manuals

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -6,6 +6,7 @@ class ManualsController < ApplicationController
   before_action :render_employment_income_manual
   before_action :ensure_manual_is_found
   before_action :ensure_document_is_found, only: :show
+  helper_method :previous_sibling, :next_sibling
 
   def index
     @manual = ManualPresenter.new(manual)
@@ -19,6 +20,7 @@ class ManualsController < ApplicationController
   def updates
     @manual = ManualPresenter.new(manual)
   end
+
 
 private
 
@@ -60,4 +62,41 @@ private
     path = '/' + [params[:prefix], manual_id, section_id].compact.join('/')
     content_store.content_item(path)
   end
+
+  def parent
+    if @document.section_id && @document.breadcrumbs.empty?
+      return @manual
+    end
+  end
+
+  def previous_sibling
+    if parent
+      parent.section_groups.each do |section_group|
+        section_group.sections.each_with_index do |section, index|
+          if section.section_id == @document.section_id
+            if index != 0
+              return section_group.sections[index - 1]
+            end
+          end
+        end
+      end
+    end
+    return nil
+  end
+
+  def next_sibling
+    if parent
+      parent.section_groups.each do |section_group|
+        section_group.sections.each_with_index do |section, index|
+          if section.section_id == @document.section_id
+            if index != section_group.sections.length - 1
+              return section_group.sections[index + 1]
+            end
+          end
+        end
+      end
+    end
+    return nil
+  end
+
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -64,18 +64,22 @@ private
   end
 
   def parent
-    if @document.section_id && @document.breadcrumbs.empty?
-      return @manual
+    if @document.section_id 
+      if @document.breadcrumbs.empty?
+        return manual
+      else
+        return content_store.content_item(@document.breadcrumbs.last.link)
+      end
     end
   end
 
   def previous_sibling
     if parent
-      parent.section_groups.each do |section_group|
-        section_group.sections.each_with_index do |section, index|
+      parent.details.child_section_groups.each do |section_group|
+        section_group.child_sections.each_with_index do |section, index|
           if section.section_id == @document.section_id
             if index != 0
-              return section_group.sections[index - 1]
+              return section_group.child_sections[index - 1]
             end
           end
         end
@@ -86,11 +90,11 @@ private
 
   def next_sibling
     if parent
-      parent.section_groups.each do |section_group|
-        section_group.sections.each_with_index do |section, index|
+      parent.details.child_section_groups.each do |section_group|
+        section_group.child_sections.each_with_index do |section, index|
           if section.section_id == @document.section_id
-            if index != section_group.sections.length - 1
-              return section_group.sections[index + 1]
+            if index != section_group.child_sections.length - 1 
+              return section_group.child_sections[index + 1]
             end
           end
         end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -13,8 +13,7 @@ class ManualsController < ApplicationController
 
   def show
     @manual = ManualPresenter.new(manual)
-    @document = DocumentPresenter.new(document, @manual)
-    @siblings = SiblingPresenter.new(@document.section_id, parent)
+    @document = DocumentPresenter.new(document, manual, @manual)
   end
 
   def updates
@@ -61,16 +60,6 @@ private
   def fetch(manual_id, section_id = nil)
     path = '/' + [params[:prefix], manual_id, section_id].compact.join('/')
     content_store.content_item(path)
-  end
-
-  def parent
-    if @document.section_id 
-      if @document.breadcrumbs.empty?
-        return manual
-      else
-        return content_store.content_item(@document.breadcrumbs.last.link)
-      end
-    end
   end
 
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -6,7 +6,6 @@ class ManualsController < ApplicationController
   before_action :render_employment_income_manual
   before_action :ensure_manual_is_found
   before_action :ensure_document_is_found, only: :show
-  helper_method :previous_sibling, :next_sibling
 
   def index
     @manual = ManualPresenter.new(manual)
@@ -15,6 +14,7 @@ class ManualsController < ApplicationController
   def show
     @manual = ManualPresenter.new(manual)
     @document = DocumentPresenter.new(document, @manual)
+    @siblings = SiblingPresenter.new(@document.section_id, parent)
   end
 
   def updates
@@ -71,36 +71,6 @@ private
         return content_store.content_item(@document.breadcrumbs.last.link)
       end
     end
-  end
-
-  def previous_sibling
-    if parent
-      parent.details.child_section_groups.each do |section_group|
-        section_group.child_sections.each_with_index do |section, index|
-          if section.section_id == @document.section_id
-            if index != 0
-              return section_group.child_sections[index - 1]
-            end
-          end
-        end
-      end
-    end
-    return nil
-  end
-
-  def next_sibling
-    if parent
-      parent.details.child_section_groups.each do |section_group|
-        section_group.child_sections.each_with_index do |section, index|
-          if section.section_id == @document.section_id
-            if index != section_group.child_sections.length - 1 
-              return section_group.child_sections[index + 1]
-            end
-          end
-        end
-      end
-    end
-    return nil
   end
 
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -42,24 +42,26 @@ private
   end
 
   def manual
-    fetch(manual_id)
+    content_store.content_item(manual_base_path)
   end
 
-  def document
-    fetch(manual_id, document_id)
+  def manual_base_path
+    "/#{params[:prefix]}/#{manual_id}"
   end
 
   def manual_id
     params["manual_id"]
   end
 
+  def document
+    document_repository.fetch(document_base_path)
+  end
+
+  def document_base_path
+    "/#{params[:prefix]}/#{manual_id}/#{document_id}"
+  end
+
   def document_id
     params["section_id"]
   end
-
-  def fetch(manual_id, section_id = nil)
-    path = '/' + [params[:prefix], manual_id, section_id].compact.join('/')
-    content_store.content_item(path)
-  end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,26 @@ module ApplicationHelper
     content_tag(:time, localize(date, format: format), datetime: date.iso8601)
   end
 
+  def previous_and_next_links(document)
+    siblings = {}
+
+    if document.siblings.previous
+      siblings.merge!( 
+        previous_page: {
+          "title" => "Previous page",
+          "url" => document.siblings.previous.base_path
+        }
+      )
+    end
+    if document.siblings.next
+      siblings.merge!(
+        next_page: {
+          "title" => "Next page",
+          "url" => document.siblings.next.base_path
+        }
+      )
+    end
+    siblings
+  end
+
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,9 +1,11 @@
 class DocumentPresenter
+  include GdsApi::Helpers
   delegate :title, to: :document
 
-  def initialize(document, manual)
+  def initialize(document, raw_manual, manual)
     @document = document
     @manual = manual
+    @raw_manual = raw_manual
   end
 
   def section_id
@@ -51,6 +53,20 @@ class DocumentPresenter
     # If only one level of headings are given, this returns 1. 2 is returned for 2, etc.
     # Only ever expecting this to return 1 or 2, but the codde that uses this method will work for higher integers too.
     return 1
+  end
+
+  def parent
+    if section_id 
+      if breadcrumbs.empty?
+        @raw_manual
+      else
+        content_store.content_item(breadcrumbs.last.link)
+      end
+    end
+  end
+
+  def siblings
+    SiblingPresenter.new(section_id, parent)
   end
 
 private

--- a/app/presenters/sibling_presenter.rb
+++ b/app/presenters/sibling_presenter.rb
@@ -31,6 +31,37 @@ class SiblingPresenter
     return nil
   end
 
+  def prepare_for_navigation_component
+    if previous_sibling and next_sibling
+      { 
+        previous_page: {
+          "title" => "Previous page",
+          "url" =>  previous_sibling.base_path
+        },
+        next_page: {
+          "title" => "Next page",
+          "url" => next_sibling.base_path
+        }
+      } 
+    elsif previous_sibling
+      { 
+        previous_page: {
+          "title" => "Previous page",
+          "url" =>  previous_sibling.base_path
+        }
+      } 
+    elsif next_sibling
+      { 
+        next_page: {
+          "title" => "Next page",
+          "url" => next_sibling.base_path
+        }
+      } 
+    else 
+      {}
+    end
+  end
+
 private
 
   def section_groups

--- a/app/presenters/sibling_presenter.rb
+++ b/app/presenters/sibling_presenter.rb
@@ -1,0 +1,44 @@
+class SiblingPresenter
+
+  def initialize(current_section_id, parent)
+    @current_section_id = current_section_id
+    @parent = parent
+  end
+
+  def previous_sibling
+    section_groups.each do |section_group|
+      section_group.child_sections.each_with_index do |section, index|
+        if section.section_id == @current_section_id
+          if index != 0
+            return section_group.child_sections[index - 1]
+          end
+        end
+      end
+    end
+    return nil
+  end
+
+  def next_sibling
+    section_groups.each do |section_group|
+      section_group.child_sections.each_with_index do |section, index|
+        if section.section_id == @current_section_id
+          if index != section_group.child_sections.length - 1 
+            return section_group.child_sections[index + 1]
+          end
+        end
+      end
+    end
+    return nil
+  end
+
+private
+
+  def section_groups
+    if @parent
+      @parent.details.child_section_groups
+    else
+      []
+    end
+  end
+
+end

--- a/app/presenters/sibling_presenter.rb
+++ b/app/presenters/sibling_presenter.rb
@@ -5,7 +5,7 @@ class SiblingPresenter
     @parent = parent
   end
 
-  def previous_sibling
+  def previous
     section_groups.each do |section_group|
       section_group.child_sections.each_with_index do |section, index|
         if section.section_id == @current_section_id
@@ -18,7 +18,7 @@ class SiblingPresenter
     return nil
   end
 
-  def next_sibling
+  def next
     section_groups.each do |section_group|
       section_group.child_sections.each_with_index do |section, index|
         if section.section_id == @current_section_id
@@ -29,37 +29,6 @@ class SiblingPresenter
       end
     end
     return nil
-  end
-
-  def prepare_for_navigation_component
-    if previous_sibling and next_sibling
-      { 
-        previous_page: {
-          "title" => "Previous page",
-          "url" =>  previous_sibling.base_path
-        },
-        next_page: {
-          "title" => "Next page",
-          "url" => next_sibling.base_path
-        }
-      } 
-    elsif previous_sibling
-      { 
-        previous_page: {
-          "title" => "Previous page",
-          "url" =>  previous_sibling.base_path
-        }
-      } 
-    elsif next_sibling
-      { 
-        next_page: {
-          "title" => "Next page",
-          "url" => next_sibling.base_path
-        }
-      } 
-    else 
-      {}
-    end
   end
 
 private

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -1,0 +1,26 @@
+require "gds_api/content_store"
+
+class DocumentRepository
+  def fetch(base_path)
+    document = fetch_content_item(base_path)
+    parent = fetch_content_item(
+      extract_parent_base_path_from_document(document)
+    )
+
+  end
+
+private
+  def fetch_content_item(base_path)
+    content_store.content_item(base_path)
+  end
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.new.find("content-store"))
+  end
+
+  def extract_parent_base_path_from_document(document)
+  end
+
+  def workout_the_siblings
+  end
+end

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -16,13 +16,10 @@
         <% @document.section_groups.each do | group | %>
         <%= render 'hmrc_sections', :group => group %>
       <% end %>
-      <% if previous_sibling %>
-        <%= link_to previous_sibling.title, previous_sibling.base_path %>
-      <% end %>
-      <% if next_sibling %>
-        <%= link_to next_sibling.title, next_sibling.base_path %>
-      <% end %>
       </div>
+
+      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: @siblings.prepare_for_navigation_component %>
+
     <% else %>
       <% if @document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= @document.collapse_depth %>>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -16,6 +16,14 @@
         <% @document.section_groups.each do | group | %>
         <%= render 'hmrc_sections', :group => group %>
       <% end %>
+      <% if previous_sibling %>
+        <%= previous_sibling.title %>
+        <%= link_to previous_sibling.title, previous_sibling.path %>
+      <% end %>
+      <% if next_sibling %>
+        <%= next_sibling.title %>
+        <%= link_to next_sibling.title, next_sibling.path %>
+      <% end %>
       </div>
     <% else %>
       <% if @document.body.present? %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -18,7 +18,7 @@
       <% end %>
       </div>
 
-      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: @siblings.prepare_for_navigation_component %>
+      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: previous_and_next_links(@document) %>
 
     <% else %>
       <% if @document.body.present? %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -17,12 +17,10 @@
         <%= render 'hmrc_sections', :group => group %>
       <% end %>
       <% if previous_sibling %>
-        <%= previous_sibling.title %>
-        <%= link_to previous_sibling.title, previous_sibling.path %>
+        <%= link_to previous_sibling.title, previous_sibling.base_path %>
       <% end %>
       <% if next_sibling %>
-        <%= next_sibling.title %>
-        <%= link_to next_sibling.title, next_sibling.path %>
+        <%= link_to next_sibling.title, next_sibling.base_path %>
       <% end %>
       </div>
     <% else %>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -50,6 +50,13 @@ feature "Viewing manuals and sections" do
 
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
+
+    #previous page
+    expect(page).to have_link("About this manual",
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00100")
+    #next page
+    expect(page).to have_link("Self assessment tax",
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00900")
   end
 
   scenario "viewing a sub-sub section" do

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -53,12 +53,8 @@ feature "Viewing manuals and sections" do
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
 
-    #previous page
-    expect(page).to have_link("About this manual",
-                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00100")
-    #next page
-    expect(page).to have_link("Self assessment tax",
-                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00900")
+    expect_page_to_contain_navigation_link("Previous page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00100")
+    expect_page_to_contain_navigation_link("Next page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00900")
   end
 
   scenario "viewing a sub-sub section" do
@@ -72,12 +68,9 @@ feature "Viewing manuals and sections" do
                               href: "/hmrc-internal-manuals/inheritance-tax-manual")
     expect(page).to have_link("EIM00500",
                               href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
-    #previous page
-    expect(page).to have_link("Introduction to particular items",
-                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
-    #next page
-    expect(page).to have_link("Particular items: R to Z",
-                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
+
+    expect_page_to_contain_navigation_link("Previous page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
+    expect_page_to_contain_navigation_link("Next page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
   end
 
   scenario "visiting a manual section with a body" do

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -39,10 +39,12 @@ feature "Viewing manuals and sections" do
 
     expect_a_child_section_group_title_of("This is a dummy child_section_group title")
 
-    expect_page_to_include_section("General",
-                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505")
+    expect_page_to_include_section("Introduction to particular items",
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
     expect_page_to_include_section("Particular items: A to P",
-                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520")
+    expect_page_to_include_section("Particular items: R to Z",
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
 
     # breadcrumb
     expect(page).to have_link("Contents",
@@ -61,14 +63,21 @@ feature "Viewing manuals and sections" do
 
   scenario "viewing a sub-sub section" do
     stub_hmrc_manual
+    stub_hmrc_manual_section_with_subsections
     stub_hmrc_manual_sub_sub_section
 
-    visit_hmrc_manual_section "inheritance-tax-manual", "eim00501"
+    visit_hmrc_manual_section "inheritance-tax-manual", "eim00520"
 
     expect(page).to have_link("Contents",
                               href: "/hmrc-internal-manuals/inheritance-tax-manual")
     expect(page).to have_link("EIM00500",
                               href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
+    #previous page
+    expect(page).to have_link("Introduction to particular items",
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
+    #next page
+    expect(page).to have_link("Particular items: R to Z",
+                              href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
   end
 
   scenario "visiting a manual section with a body" do

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -81,6 +81,11 @@ module AppHelpers
       expect(page).to have_content(change_note)
     end
   end
+
+  def expect_page_to_contain_navigation_link(title, url)
+    expect(page).to have_content(title)
+    expect(page).to have_content(url)
+  end
 end
 
 RSpec.configuration.include AppHelpers, type: :feature

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -114,14 +114,19 @@ module ManualHelpers
             title: "This is a dummy child_section_group title",
             child_sections: [
               {
-                section_id: "EIM00505",
-                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505",
-                title: "General",
+                section_id: "EIM00510",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510",
+                title: "Introduction to particular items",
               },
               {
-                section_id: "EIM01000",
-                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000",
+                section_id: "EIM00520",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520",
                 title: "Particular items: A to P",
+              },
+              {
+                section_id: "EIM00530",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530",
+                title: "Particular items: R to Z",
               },
             ]
           }
@@ -134,8 +139,8 @@ module ManualHelpers
 
   def stub_hmrc_manual_sub_sub_section
     section_json = {
-      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00501",
-      title: "Inheritance tax: table of contents",
+      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520",
+      title: "Particular items: A to P",
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
@@ -147,11 +152,11 @@ module ManualHelpers
           }
         ],
         body: "Some body to love",
-        section_id: "eim00501"
+        section_id: "EIM00520"
       }
     }
 
-    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00501", section_json)
+    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00520", section_json)
   end
 
   def stub_hmrc_manual_section_with_body(manual_id="inheritance-tax-manual", section_id="eim15000",

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -77,6 +77,11 @@ module ManualHelpers
                 base_path: "/hmrc-internal-manuals/#{manual_id}/eim00500",
                 title: "Inheritance tax",
               },
+              {
+                section_id: "EIM00900",
+                base_path: "/hmrc-internal-manuals/#{manual_id}/eim00900",
+                title: "Self assessment tax",
+              },
             ]
           }
         ],

--- a/spec/unit/document_repository_spec.rb
+++ b/spec/unit/document_repository_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe DocumentRepository do
+  subject(:document_repository) {
+    DocumentRepository.new
+  }
+
+  let(:document) {
+    document_repository.fetch(document_base_path)
+  }
+
+  let(:document_base_path) {
+    "/guidance/a-manual/a-section"
+  }
+
+  let(:document_content_item_json) {
+    {
+      base_path: document_base_path,
+      details: {
+        breadcrumbs: [
+          {
+            section_id: "EIM00500",
+            base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500"
+          }
+        ],
+        section_id: "EIM00520",
+      }
+    }
+  }
+
+  describe "#fetch" do
+    before do
+      content_store_has_item(
+        document_base_path,
+        document_content_item_json,
+      )
+    end
+
+    it "should return a document content item" do
+      expect(document.base_path).to eq(document_base_path)
+    end
+
+    context "a section that is an only-child" do
+      it "#previous_sibling should be nil" do
+        expect(document.previous_sibling).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/sibling_presenter_spec.rb
+++ b/spec/unit/sibling_presenter_spec.rb
@@ -11,8 +11,8 @@ describe SiblingPresenter do
     let(:presenter) { SiblingPresenter.new(nil, nil) }
 
     it "should not have siblings" do
-      expect(presenter.previous_sibling).to be_nil
-      expect(presenter.next_sibling).to be_nil
+      expect(presenter.previous).to be_nil
+      expect(presenter.next).to be_nil
     end
   end
 
@@ -38,8 +38,8 @@ describe SiblingPresenter do
       let(:presenter) { SiblingPresenter.new("EIM00510", parent) }
 
       it "should have next but not previous sibling" do
-        expect(presenter.previous_sibling).to be_nil
-        expect(presenter.next_sibling.section_id).to eq("EIM00520")
+        expect(presenter.previous).to be_nil
+        expect(presenter.next.section_id).to eq("EIM00520")
       end
     end
 
@@ -47,8 +47,8 @@ describe SiblingPresenter do
       let(:presenter) { SiblingPresenter.new("EIM00520", parent) }
 
       it "should have previous and next siblings" do
-        expect(presenter.previous_sibling.section_id).to eq("EIM00510")
-        expect(presenter.next_sibling.section_id).to eq("EIM00530")
+        expect(presenter.previous.section_id).to eq("EIM00510")
+        expect(presenter.next.section_id).to eq("EIM00530")
       end
     end
 
@@ -56,8 +56,8 @@ describe SiblingPresenter do
       let(:presenter) { SiblingPresenter.new("EIM00530", parent) }
 
       it "should have previous but not next sibling" do
-        expect(presenter.previous_sibling.section_id).to eq("EIM00520")
-        expect(presenter.next_sibling).to be_nil
+        expect(presenter.previous.section_id).to eq("EIM00520")
+        expect(presenter.next).to be_nil
       end
     end
 
@@ -65,8 +65,8 @@ describe SiblingPresenter do
       let(:presenter) { SiblingPresenter.new("EIM00600", parent) }
 
       it "should have no siblings" do
-        expect(presenter.previous_sibling).to be_nil
-        expect(presenter.next_sibling).to be_nil
+        expect(presenter.previous).to be_nil
+        expect(presenter.next).to be_nil
       end
     end
 
@@ -91,8 +91,8 @@ describe SiblingPresenter do
     let(:presenter) { SiblingPresenter.new("EIM00600", parent) }
 
     it "should have no siblings" do
-      expect(presenter.previous_sibling).to be_nil
-      expect(presenter.next_sibling).to be_nil
+      expect(presenter.previous).to be_nil
+      expect(presenter.next).to be_nil
     end
   end
 
@@ -122,8 +122,8 @@ describe SiblingPresenter do
     let(:presenter) { SiblingPresenter.new("EIM00800", parent) }
 
     it "should have previous and next siblings" do
-      expect(presenter.previous_sibling.section_id).to eq("EIM00700")
-      expect(presenter.next_sibling.section_id).to eq("EIM00900")
+      expect(presenter.previous.section_id).to eq("EIM00700")
+      expect(presenter.next.section_id).to eq("EIM00900")
     end
   end
 

--- a/spec/unit/sibling_presenter_spec.rb
+++ b/spec/unit/sibling_presenter_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+describe SiblingPresenter do
+
+  Parent = Struct.new(:details)
+  Details = Struct.new(:child_section_groups)
+  ChildSectionGroup = Struct.new(:child_sections)
+  ChildSection = Struct.new(:section_id)
+  
+  context "current section is at the top level of the manual" do
+    let(:presenter) { SiblingPresenter.new(nil, nil) }
+
+    it "should not have siblings" do
+      expect(presenter.previous_sibling).to be_nil
+      expect(presenter.next_sibling).to be_nil
+    end
+  end
+
+  context "current section has a parent with multiple children" do
+
+    let(:parent) {
+      Parent.new(
+        Details.new(
+          [
+            ChildSectionGroup.new(
+              [
+                ChildSection.new("EIM00510"),
+                ChildSection.new("EIM00520"),
+                ChildSection.new("EIM00530"),
+              ]
+            )
+          ]
+        )
+      )
+    }
+
+    context "current section is the first child" do
+      let(:presenter) { SiblingPresenter.new("EIM00510", parent) }
+
+      it "should have next but not previous sibling" do
+        expect(presenter.previous_sibling).to be_nil
+        expect(presenter.next_sibling.section_id).to eq("EIM00520")
+      end
+    end
+
+    context "current section is the mid child" do
+      let(:presenter) { SiblingPresenter.new("EIM00520", parent) }
+
+      it "should have previous and next siblings" do
+        expect(presenter.previous_sibling.section_id).to eq("EIM00510")
+        expect(presenter.next_sibling.section_id).to eq("EIM00530")
+      end
+    end
+
+    context "current section is the last child" do
+      let(:presenter) { SiblingPresenter.new("EIM00530", parent) }
+
+      it "should have previous but not next sibling" do
+        expect(presenter.previous_sibling.section_id).to eq("EIM00520")
+        expect(presenter.next_sibling).to be_nil
+      end
+    end
+
+    context "current section is not in the list" do
+      let(:presenter) { SiblingPresenter.new("EIM00600", parent) }
+
+      it "should have no siblings" do
+        expect(presenter.previous_sibling).to be_nil
+        expect(presenter.next_sibling).to be_nil
+      end
+    end
+
+  end
+
+  context "current section has a parent with a single child (self)" do
+
+    let(:parent) {
+      Parent.new(
+        Details.new(
+          [
+            ChildSectionGroup.new(
+              [
+                ChildSection.new("EIM00600"),
+              ]
+            )
+          ]
+        )
+      )
+    }
+
+    let(:presenter) { SiblingPresenter.new("EIM00600", parent) }
+
+    it "should have no siblings" do
+      expect(presenter.previous_sibling).to be_nil
+      expect(presenter.next_sibling).to be_nil
+    end
+  end
+
+  context "parent has multiple section groups" do
+
+    let(:parent) {
+      Parent.new(
+        Details.new(
+          [
+            ChildSectionGroup.new(
+              [
+                ChildSection.new("EIM00600")
+              ]
+            ),
+            ChildSectionGroup.new(
+              [
+                ChildSection.new("EIM00700"),
+                ChildSection.new("EIM00800"),
+                ChildSection.new("EIM00900"),
+              ]
+            )
+          ]
+        )
+      )
+    }
+
+    let(:presenter) { SiblingPresenter.new("EIM00800", parent) }
+
+    it "should have previous and next siblings" do
+      expect(presenter.previous_sibling.section_id).to eq("EIM00700")
+      expect(presenter.next_sibling.section_id).to eq("EIM00900")
+    end
+  end
+
+end


### PR DESCRIPTION
Adding navigational links to HMRC manuals hasn't been simple and many people had many different ideas on how to approach the issue. 

1 - Get HMRC to provide us previous and next links and simply displaying them within a view in manuals-frontend
2 - Get the content-store to calculate previous and next links and attach them to section schemas
3 - Calculate previous and next links within manuals-frontend:
4 - Doing it within the ManualsController
5 - Doing it within the DocumentPresenter
6 - Create an API app that will live between the content-store and manuals-frontend

I've implemented points 4 and 5.

the last commit addresses 5 the previous ones address 4.

DISCLAIMER: refactoring needed, commit messages re-editing needed

@fatbusinessman  @alicebartlett  @evilstreak 