### PR TITLE
Add print this page link to manuals to print full page

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -2,11 +2,17 @@ a {
   text-decoration: none;
 }
 
-// hide all the things
+// hide all the unecessary things
 .alpha-label,
-.breadcrumb-trail {
+.breadcrumb-trail,
+.js-title-controls-wrap,
+.print-page,
+.secondary {
   display: none;
 }
+
+// removing .secondary from print because this now only contains 'Give feedback about this page' which isn't useful on a printed page
+
 
 .primary {
   h1 {
@@ -36,10 +42,6 @@ a {
   }
 }
 
-.secondary {
-  display: none; // removing from print because this now only contains 'Give feedback about this page' which isn't useful on a printed page
-}
-
 .manual-body {
   clear: both;
   .subsection-title-text {
@@ -49,10 +51,6 @@ a {
 
 .govspeak {
   width: 75%;
-}
-
-.js-title-controls-wrap {
-  display: none;
 }
 
 .js-openable {

--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -7,12 +7,9 @@ a {
 .breadcrumb-trail,
 .js-title-controls-wrap,
 .print-page,
-.secondary {
+.secondary .feedback {
   display: none;
 }
-
-// removing .secondary from print because this now only contains 'Give feedback about this page' which isn't useful on a printed page
-
 
 .primary {
   h1 {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,7 +25,7 @@ main {
 }
 
 #manuals-frontend {
-  padding-bottom:$gutter*3;
+  padding-bottom:$gutter;
 
   .govuk-beta-label {
     border-bottom: none;
@@ -192,7 +192,7 @@ main {
   }
 
   .manual-body {
-    margin-top: $gutter-half;
+    margin: $gutter-half 0 $gutter*3;
     @include media(tablet){
       margin-top: $gutter;
     }
@@ -370,4 +370,13 @@ main {
     padding-right: $gutter-half;
 
   }
+
+  .print-page {
+    display: none;
+
+    .js-enabled & {
+      display: block;
+    }
+  }
+
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,9 @@
     <main role="main" class="hmrc-internal-manuals-frontend-content outer-block">
       <div id="manuals-frontend" class='inner-block'>
         <%= yield %>
+        <div class="print-page">
+          <%= link_to 'Print this page', '#', :onclick => 'window.print();return false;'%>
+        </div>
       </div>
     </main>
   </div>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -20,7 +20,7 @@
   <div class='secondary'>
     <div class='secondary-inner'>
       <p>
-        <%= link_to 'Give feedback about this page', 'https://www.gov.uk/contact/govuk' %>
+        <%= link_to 'Give feedback about this page', 'https://www.gov.uk/contact/govuk', :class=> "feedback" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Add print this page link to manuals to print full page even folded
sections on subsection pages.

To make printing easier/more obvious to users who want to print
manuals we've added a "Print this page" to all pages on manuals.
This works for HMRC manuals too.

• added the link to application.html.erb so that it appears on
all pages
• updated styles with input from Rebecca Cottrell on layout/spacing
• added default styles hide element, but included styles to show
element when javascript is enabled
• tested on mobile and IE6, 7, 8 and 9 and works as expected

https://www.pivotaltracker.com/story/show/88435406

manual before -
![screen shot 2015-03-11 at 17 09 14](https://cloud.githubusercontent.com/assets/1692222/6602101/7e161df2-c811-11e4-8987-efda75ed70dc.png)
manual after -
![screen shot 2015-03-11 at 17 08 38](https://cloud.githubusercontent.com/assets/1692222/6602108/8906db8e-c811-11e4-86cd-afa616d3e5e6.png)

HMRC before -
![screen shot 2015-03-11 at 17 09 34](https://cloud.githubusercontent.com/assets/1692222/6602114/93043366-c811-11e4-90c8-2f549eca630e.png)
HMRC after -
![screen shot 2015-03-11 at 17 08 12](https://cloud.githubusercontent.com/assets/1692222/6602118/9ced4214-c811-11e4-8aec-cdf384ebfbd7.png)



