### PR TITLE
Improvements to print stylesheets for manuals

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -10,57 +10,49 @@ a {
 
 .primary {
   h1 {
-    margin-bottom: 5px;
+    margin: 0 0 10px;
+    padding: 0 0 10px;
+    font-weight: bold;
   }
 
   dl {
     float: left;
     margin-top: 0;
-    width: 25%;
-    dt,
-    dd {
-      display: block;
+    width: 100%;
+    dt {
+      min-width: 100px;
+      float: left;
+      &:after {
+        content: ":";
+      }
     }
     dd {
       font-weight: bold;
       margin-left: 0;
-      & a[href^="http://"]:after,
-      & a[href^="https://"]:after {
+      & a:after {
           content: "";
       }
-    }
-    dt:after {
-      content: ":";
     }
   }
 }
 
-#manuals-frontend header dt {
-  min-width: 0!important;
+.secondary {
+  display: none; // removing from print because this now only contains 'Give feedback about this page' which isn't useful on a printed page
 }
 
-.secondary {
-  float: left;
-  margin-bottom: 20px;
-  width: 75%;
-
-  .secondary-inner {
-    p {
-      margin-top: 0;
-      & + p {
-        display: none;
-      }
-    }
-
-    time {
-      font-weight: bold;
-      display: block;
-    }
+.manual-body {
+  clear: both;
+  .subsection-title-text {
+    font-weight: bold;
   }
 }
 
 .govspeak {
   width: 75%;
+}
+
+.js-title-controls-wrap {
+  display: none;
 }
 
 .js-openable {


### PR DESCRIPTION
Improvements made are to improve design and layout of the printed page
and to improve readability.

See screenshots attached for side by side comparisons.
(left image is after, right image is before)

Changes made -
• Hide 'open all' and 'close all' links
• Hide 'Give feedback about this page' link
• clear main content from floating up next to the header metadata
• Remove URLs displaying after header metadata links
• display dt's and dl's inline to match metadata format seen on other
publication formats
• update spacing for h1 in HMRC header to match on screen look closer
• bold h1 for clarity
• bold sub headings for clarity and better scanning

https://www.pivotaltracker.com/story/show/90180042

![screen shot 2015-03-12 at 16 40 38](https://cloud.githubusercontent.com/assets/1692222/6623365/6de86506-c8da-11e4-9098-f4a983a6c9be.png)
![screen shot 2015-03-12 at 16 40 57](https://cloud.githubusercontent.com/assets/1692222/6623368/6dec65e8-c8da-11e4-932f-3848533de4df.png)
![screen shot 2015-03-12 at 16 41 19](https://cloud.githubusercontent.com/assets/1692222/6623366/6deb4b86-c8da-11e4-8f20-355a49691274.png)
![screen shot 2015-03-12 at 16 41 36](https://cloud.githubusercontent.com/assets/1692222/6623367/6dec6c32-c8da-11e4-91d4-fe8602e543e0.png)
![screen shot 2015-03-12 at 16 41 53](https://cloud.githubusercontent.com/assets/1692222/6623369/6deca8b4-c8da-11e4-9acd-1c78f57495f4.png)
