### PR TITLE
Refactor manuals controller

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -5,15 +5,13 @@ class ManualsController < ApplicationController
 
   before_action :render_employment_income_manual
   before_action :ensure_manual_is_found
+  before_action :ensure_document_is_found, only: :show
 
   def index
     @manual = ManualPresenter.new(manual)
   end
 
   def show
-    document = fetch(params["manual_id"], params["section_id"])
-    error_not_found unless document
-
     @manual = ManualPresenter.new(manual)
     @document = DocumentPresenter.new(document, @manual)
   end
@@ -34,12 +32,20 @@ private
     error_not_found unless manual
   end
 
+  def ensure_document_is_found
+    error_not_found unless document
+  end
+
   def error_not_found
     render status: :not_found, text: "404 error not found"
   end
 
   def manual
     fetch(params["manual_id"])
+  end
+
+  def document
+    fetch(params["manual_id"], params["section_id"])
   end
 
   def fetch(manual_id, section_id = nil)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -3,17 +3,20 @@ require 'gds_api/helpers'
 class ManualsController < ApplicationController
   include GdsApi::Helpers
 
-  before_filter :set_manual
-
-  def index; end
+  def index
+    @manual = ManualPresenter.new(manual)
+  end
 
   def show
     document = fetch(params["manual_id"], params["section_id"])
     error_not_found unless document
+
+    @manual = ManualPresenter.new(manual)
     @document = DocumentPresenter.new(document, @manual)
   end
 
   def updates
+    @manual = ManualPresenter.new(manual)
   end
 
 private
@@ -22,7 +25,7 @@ private
     render status: :not_found, text: "404 error not found"
   end
 
-  def set_manual
+  def manual
     manual = fetch(params["manual_id"])
     unless manual
       if params["manual_id"] == 'employment-income-manual'
@@ -31,7 +34,7 @@ private
         error_not_found
       end
     end
-    @manual = ManualPresenter.new(manual)
+    manual
   end
 
   def fetch(manual_id, section_id = nil)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -23,7 +23,7 @@ class ManualsController < ApplicationController
 private
 
   def render_employment_income_manual
-    if manual.nil? && params["manual_id"] == "employment-income-manual"
+    if manual.nil? && manual_id == "employment-income-manual"
       render :employment_income_manual
     end
   end
@@ -41,11 +41,19 @@ private
   end
 
   def manual
-    fetch(params["manual_id"])
+    fetch(manual_id)
   end
 
   def document
-    fetch(params["manual_id"], params["section_id"])
+    fetch(manual_id, document_id)
+  end
+
+  def manual_id
+    params["manual_id"]
+  end
+
+  def document_id
+    params["section_id"]
   end
 
   def fetch(manual_id, section_id = nil)

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -3,6 +3,9 @@ require 'gds_api/helpers'
 class ManualsController < ApplicationController
   include GdsApi::Helpers
 
+  before_action :render_employment_income_manual
+  before_action :ensure_manual_is_found
+
   def index
     @manual = ManualPresenter.new(manual)
   end
@@ -21,20 +24,22 @@ class ManualsController < ApplicationController
 
 private
 
+  def render_employment_income_manual
+    if manual.nil? && params["manual_id"] == "employment-income-manual"
+      render :employment_income_manual
+    end
+  end
+
+  def ensure_manual_is_found
+    error_not_found unless manual
+  end
+
   def error_not_found
     render status: :not_found, text: "404 error not found"
   end
 
   def manual
-    manual = fetch(params["manual_id"])
-    unless manual
-      if params["manual_id"] == 'employment-income-manual'
-        render :employment_income_manual
-      else
-        error_not_found
-      end
-    end
-    manual
+    fetch(params["manual_id"])
   end
 
   def fetch(manual_id, section_id = nil)


### PR DESCRIPTION
Refactor the way manuals and documents are loaded and checked by the manuals controller. Push everything towards smaller methods with a single purpose. I believe these changes make it easier to see how the controller works, and will make it more straightforward to change the way manuals and documents are loaded in the future (eg as part of #132)