### PR TITLE
Add previous and next links to HMRC manual

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -41,23 +41,30 @@ private
   end
 
   def manual
-    fetch(manual_id)
+    content_store.content_item(manual_base_path)
   end
 
-  def document
-    fetch(manual_id, document_id)
+  def manual_base_path
+    "/#{params[:prefix]}/#{manual_id}"
   end
 
   def manual_id
     params["manual_id"]
   end
 
+  def document
+    document_repository.fetch(document_base_path)
+  end
+
+  def document_base_path
+    "/#{params[:prefix]}/#{manual_id}/#{document_id}"
+  end
+
   def document_id
     params["section_id"]
   end
 
-  def fetch(manual_id, section_id = nil)
-    path = '/' + [params[:prefix], manual_id, section_id].compact.join('/')
-    content_store.content_item(path)
+  def document_repository
+    DocumentRepository.new
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,28 @@ module ApplicationHelper
     content_tag(:time, localize(date, format: format), datetime: date.iso8601)
   end
 
+  def previous_and_next_links(document)
+    siblings = {}
+
+    if document.previous_sibling
+      siblings.merge!( 
+        previous_page: {
+          "title" => "Previous page",
+          "url" => document.previous_sibling.base_path
+        }
+      )
+    end
+
+    if document.next_sibling
+      siblings.merge!(
+        next_page: {
+          "title" => "Next page",
+          "url" => document.next_sibling.base_path
+        }
+      )
+    end
+
+    siblings
+  end
+
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,5 +1,5 @@
 class DocumentPresenter
-  delegate :title, to: :document
+  delegate :title, :previous_sibling, :next_sibling, to: :document
 
   def initialize(document, manual)
     @document = document

--- a/app/presenters/sibling_decorator.rb
+++ b/app/presenters/sibling_decorator.rb
@@ -1,0 +1,47 @@
+class SiblingDecorator < SimpleDelegator
+  def initialize(document:, parent:)
+    @parent = parent
+
+    super(document)
+  end
+
+  def previous_sibling
+    adjacent_siblings.first
+  end
+
+  def next_sibling
+    adjacent_siblings.last
+  end
+
+private
+  attr_reader :parent
+
+  def current_section_id
+    details.section_id
+  end
+
+  def siblings
+    parent.details.child_section_groups.map(&:child_sections).find { |section|
+      section.map(&:section_id).include?(current_section_id)
+    }
+  end
+
+  def adjacent_siblings
+    if siblings
+      before, after = siblings.split { |section|
+        section.section_id == current_section_id
+      }
+
+      [
+        before.last,
+        after.first,
+      ]
+    else
+      [
+        nil,
+        nil,
+      ]
+    end
+  end
+
+end

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -1,0 +1,39 @@
+require "gds_api/content_store"
+
+class DocumentRepository
+  def fetch(base_path)
+    document = fetch_content_item(base_path)
+
+    if document
+      parent = fetch_parent_for_document(document)
+
+      SiblingDecorator.new(
+        document: document,
+        parent: parent,
+      )
+    end
+  end
+
+private
+  def fetch_content_item(base_path)
+    content_store.content_item(base_path)
+  end
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.new.find("content-store"))
+  end
+
+  def extract_parent_base_path_from_document(document)
+    if document.details.breadcrumbs.present?
+      document.details.breadcrumbs.last.base_path
+    else
+      document.details.manual.base_path
+    end
+  end
+
+  def fetch_parent_for_document(document)
+    fetch_content_item(
+      extract_parent_base_path_from_document(document)
+    )
+  end
+end

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -17,6 +17,9 @@
         <%= render 'hmrc_sections', :group => group %>
       <% end %>
       </div>
+
+      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: previous_and_next_links(@document) %>
+
     <% else %>
       <% if @document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= @document.collapse_depth %>>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -39,10 +39,12 @@ feature "Viewing manuals and sections" do
 
     expect_a_child_section_group_title_of("This is a dummy child_section_group title")
 
-    expect_page_to_include_section("General",
-                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505")
+    expect_page_to_include_section("Introduction to particular items",
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
     expect_page_to_include_section("Particular items: A to P",
-                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000")
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520")
+    expect_page_to_include_section("Particular items: R to Z",
+                                   href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
 
     # breadcrumb
     expect(page).to have_link("Contents",
@@ -54,9 +56,10 @@ feature "Viewing manuals and sections" do
 
   scenario "viewing a sub-sub section" do
     stub_hmrc_manual
+    stub_hmrc_manual_section_with_subsections
     stub_hmrc_manual_sub_sub_section
 
-    visit_hmrc_manual_section "inheritance-tax-manual", "eim00501"
+    visit_hmrc_manual_section "inheritance-tax-manual", "eim00520"
 
     expect(page).to have_link("Contents",
                               href: "/hmrc-internal-manuals/inheritance-tax-manual")

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -52,6 +52,9 @@ feature "Viewing manuals and sections" do
 
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
+
+    expect_page_to_contain_navigation_link("Previous page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00100")
+    expect_page_to_contain_navigation_link("Next page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00900")
   end
 
   scenario "viewing a sub-sub section" do
@@ -65,6 +68,9 @@ feature "Viewing manuals and sections" do
                               href: "/hmrc-internal-manuals/inheritance-tax-manual")
     expect(page).to have_link("EIM00500",
                               href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
+
+    expect_page_to_contain_navigation_link("Previous page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00510")
+    expect_page_to_contain_navigation_link("Next page", "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
   end
 
   scenario "visiting a manual section with a body" do

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -81,6 +81,11 @@ module AppHelpers
       expect(page).to have_content(change_note)
     end
   end
+
+  def expect_page_to_contain_navigation_link(title, url)
+    expect(page).to have_content(title)
+    expect(page).to have_content(url)
+  end
 end
 
 RSpec.configuration.include AppHelpers, type: :feature

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -77,6 +77,11 @@ module ManualHelpers
                 base_path: "/hmrc-internal-manuals/#{manual_id}/eim00500",
                 title: "Inheritance tax",
               },
+              {
+                section_id: "EIM00900",
+                base_path: "/hmrc-internal-manuals/#{manual_id}/eim00900",
+                title: "Self assessment tax",
+              },
             ]
           }
         ],
@@ -109,18 +114,26 @@ module ManualHelpers
             title: "This is a dummy child_section_group title",
             child_sections: [
               {
-                section_id: "EIM00505",
-                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00505",
-                title: "General",
+                section_id: "EIM00510",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00510",
+                title: "Introduction to particular items",
               },
               {
-                section_id: "EIM01000",
-                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim01000",
+                section_id: "EIM00520",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520",
                 title: "Particular items: A to P",
+              },
+              {
+                section_id: "EIM00530",
+                base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530",
+                title: "Particular items: R to Z",
               },
             ]
           }
-        ]
+        ],
+        manual: {
+          base_path: "/hmrc-internal-manuals/inheritance-tax-manual",
+        },
       }
     }
 
@@ -129,8 +142,8 @@ module ManualHelpers
 
   def stub_hmrc_manual_sub_sub_section
     section_json = {
-      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00501",
-      title: "Inheritance tax: table of contents",
+      base_path: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520",
+      title: "Particular items: A to P",
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
@@ -142,11 +155,14 @@ module ManualHelpers
           }
         ],
         body: "Some body to love",
-        section_id: "eim00501"
+        section_id: "EIM00520",
+        manual: {
+          base_path: "/hmrc-internal-manuals/inheritance-tax-manual",
+        },
       }
     }
 
-    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00501", section_json)
+    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00520", section_json)
   end
 
   def stub_hmrc_manual_section_with_body(manual_id="inheritance-tax-manual", section_id="eim15000",
@@ -160,7 +176,10 @@ module ManualHelpers
       details: {
         body: 'On this page:<br><br><a href="/hmrc-internal-manuals/#{manual_id}/#{section_id}#EIM15010#IDAZR1YH">Sections 386-400 ITEPA 2003]</a><br>',
         section_id: "#{section_id}",
-        child_section_groups: []
+        child_section_groups: [],
+        manual: {
+          base_path: "/hmrc-internal-manuals/#{manual_id}",
+        },
       }
     }
 

--- a/spec/unit/sibling_decorator_spec.rb
+++ b/spec/unit/sibling_decorator_spec.rb
@@ -1,0 +1,271 @@
+require 'rails_helper'
+
+describe SiblingDecorator do
+
+  let(:document_base_path) {
+    "/guidance/a-manual/child-section"
+  }
+
+  let(:manual_base_path) {
+    "/guidance/a-manual"
+  }
+
+  let(:document_id) {
+    "child-section"
+  }
+
+  let(:document) {
+    double(
+      base_path: document_base_path,
+      details: double(
+        breadcrumbs: [
+          double(
+            section_id: parent_id,
+            base_path: parent_base_path,
+          ),
+        ],
+        section_id: document_id,
+      ),
+    )
+  }
+
+  let(:parent_base_path) {
+    "/guidance/a-manual/parent-section"
+  }
+
+  let(:parent_id) {
+    "parent-section"
+  }
+
+  let(:parent) {
+    double(
+      base_path: parent_base_path,
+      details: double(
+        section_id: parent_id,
+        child_section_groups: child_section_groups,
+      ),
+    )
+  }
+
+  let(:child_section_groups) {
+    []
+  }
+
+  subject(:decorator) {
+    SiblingDecorator.new(
+      document: document,
+      parent: parent,
+    )
+  }
+
+  it "should be a decorator" do
+    expect(decorator.base_path).to eq(document_base_path)
+  end
+
+  context "for a section that is an only-child" do
+    let(:child_section_groups) {
+      [
+        double(
+          child_sections: [
+            double(
+              section_id: document_id,
+              base_path: document_base_path,
+              title: "Child section title",
+            ),
+          ]
+        )
+      ]
+    }
+
+    describe "#previous_sibling" do
+      it "should be nil" do
+        expect(decorator.previous_sibling).to be_nil
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be nil" do
+        expect(decorator.next_sibling).to be_nil
+      end
+    end
+  end
+
+  context "for a section that is a first child" do
+    let(:child_section_groups) {
+      [
+        double(
+          child_sections: [
+            double(
+              section_id: document_id,
+              base_path: document_base_path,
+              title: "Child section title",
+            ),
+            double(
+              section_id: "next-sibling",
+              base_path: "/guidance/a-manual/next-sibling",
+              title: "Next sibling title",
+            ),
+          ]
+        ),
+      ]
+    }
+
+    describe "#previous_sibling" do
+      it "should be nil" do
+        expect(decorator.previous_sibling).to be_nil
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be present" do
+        expect(decorator.next_sibling.section_id).to eq("next-sibling")
+        expect(decorator.next_sibling.base_path).to eq("/guidance/a-manual/next-sibling")
+        expect(decorator.next_sibling.title).to eq("Next sibling title")
+      end
+    end
+  end
+
+  context "for a section that is a last child" do
+    let(:child_section_groups) {
+      [
+        double(
+          child_sections: [
+            double(
+              section_id: "previous-sibling",
+              base_path: "/guidance/a-manual/previous-sibling",
+              title: "Previous sibling title",
+            ),
+            double(
+              section_id: document_id,
+              base_path: document_base_path,
+              title: "Child section title",
+            ),
+          ]
+        ),
+      ]
+    }
+
+    describe "#previous_sibling" do
+      it "should be present" do
+        expect(decorator.previous_sibling.section_id).to eq("previous-sibling")
+        expect(decorator.previous_sibling.base_path).to eq("/guidance/a-manual/previous-sibling")
+        expect(decorator.previous_sibling.title).to eq("Previous sibling title")
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be nil" do
+        expect(decorator.next_sibling).to be_nil
+      end
+    end
+  end
+
+  context "for a section that is a mid child" do
+    let(:child_section_groups) {
+      [
+        double(
+          child_sections: [
+            double(
+              section_id: "previous-sibling",
+              base_path: "/guidance/a-manual/previous-sibling",
+              title: "Previous sibling title",
+            ),
+            double(
+              section_id: document_id,
+              base_path: document_base_path,
+              title: "Child section title",
+            ),
+            double(
+              section_id: "next-sibling",
+              base_path: "/guidance/a-manual/next-sibling",
+              title: "Next sibling title",
+            ),
+          ]
+        ),
+      ]
+    }
+
+    describe "#previous_sibling" do
+      it "should be present" do
+        expect(decorator.previous_sibling.section_id).to eq("previous-sibling")
+        expect(decorator.previous_sibling.base_path).to eq("/guidance/a-manual/previous-sibling")
+        expect(decorator.previous_sibling.title).to eq("Previous sibling title")
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be present" do
+        expect(decorator.next_sibling.section_id).to eq("next-sibling")
+        expect(decorator.next_sibling.base_path).to eq("/guidance/a-manual/next-sibling")
+        expect(decorator.next_sibling.title).to eq("Next sibling title")
+      end
+    end
+
+    context "for a section not recognised by its parent" do
+      let(:child_section_groups) {
+        [
+          double(
+            child_sections: []
+          ),
+        ]
+      }
+
+      describe "#previous_sibling" do
+        it "should be nil" do
+          expect(decorator.previous_sibling).to be_nil
+        end
+      end
+
+      describe "#next_sibling" do
+        it "should be nil" do
+          expect(decorator.next_sibling).to be_nil
+        end
+      end
+    end
+  end
+
+  context "for a section that is the first child and has a cousin" do
+    let(:child_section_groups) {
+      [ 
+        double(
+          child_sections: [
+            double(
+              section_id: "cousin-section",
+              base_path: "/guidance/a-manual/cousin-section",
+              title: "Cousin section title",
+            ),
+          ]
+        ),
+        double(
+          child_sections: [
+            double(
+              section_id: document_id,
+              base_path: document_base_path,
+              title: "Child section title",
+            ),
+            double(
+              section_id: "next-sibling",
+              base_path: "/guidance/a-manual/next-sibling",
+              title: "Next sibling title",
+            ),
+          ]
+        ),
+      ]
+    }
+
+    describe "#previous_sibling" do
+      it "should be nil" do
+        expect(decorator.previous_sibling).to be_nil
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be present" do
+        expect(decorator.next_sibling.section_id).to eq("next-sibling")
+        expect(decorator.next_sibling.base_path).to eq("/guidance/a-manual/next-sibling")
+        expect(decorator.next_sibling.title).to eq("Next sibling title")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR will allow users to navigate through sections within the HMRC manual.

ticket: https://www.pivotaltracker.com/story/show/88435524

all done with the help of the splendid @fatbusinessman, @alicebartlett and @evilstreak