### PR TITLE
Allow robots to crawl and index manuals

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,16 +8,11 @@ class ApplicationController < ActionController::Base
   include Slimmer::SharedTemplates
 
   before_filter :slimmer_headers
-  before_filter :set_robots_headers
 
   private
 
   def slimmer_headers
     set_slimmer_headers(template: "header_footer_only")
-  end
-
-  def set_robots_headers
-    response.headers["X-Robots-Tag"] = "none"
   end
 
 end


### PR DESCRIPTION
Revert bcf09b91a6d78e1132ef0771ce0be2f6cdabd542 (https://github.com/alphagov/manuals-frontend/pull/36) so that Google and other bots can index and crawl manuals.

cc @evilstreak 