### PR TITLE
Prevent only HMRC manuals from being crawled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   include Slimmer::SharedTemplates
 
   before_filter :slimmer_headers
-  before_filter :set_robots_headers
 
   private
 
@@ -16,9 +15,4 @@ class ApplicationController < ActionController::Base
     set_slimmer_headers(template: "header_footer_only")
     set_slimmer_headers(remove_search: true)
   end
-
-  def set_robots_headers
-    response.headers["X-Robots-Tag"] = "none"
-  end
-
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -6,18 +6,17 @@ class ManualsController < ApplicationController
   before_action :render_employment_income_manual
   before_action :ensure_manual_is_found
   before_action :ensure_document_is_found, only: :show
+  before_action :load_manual
+  before_action :prevent_robots_from_indexing_hmrc_manuals
 
   def index
-    @manual = ManualPresenter.new(manual)
   end
 
   def show
-    @manual = ManualPresenter.new(manual)
     @document = DocumentPresenter.new(document, @manual)
   end
 
   def updates
-    @manual = ManualPresenter.new(manual)
   end
 
 private
@@ -44,6 +43,10 @@ private
     content_store.content_item(manual_base_path)
   end
 
+  def load_manual
+    @manual = ManualPresenter.new(manual)
+  end
+
   def manual_base_path
     "/#{params[:prefix]}/#{manual_id}"
   end
@@ -66,5 +69,11 @@ private
 
   def document_repository
     DocumentRepository.new
+  end
+
+  def prevent_robots_from_indexing_hmrc_manuals
+    if @manual.hmrc?
+      response.headers["X-Robots-Tag"] = "none"
+    end
   end
 end

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -28,6 +28,18 @@ feature "Viewing manuals and sections" do
                                           slug: "hm-revenue-customs")
   end
 
+  scenario "viewing a non-HMRC manual" do
+    stub_fake_manual
+    visit_manual "my-manual-about-burritos"
+    expect(page.response_headers['X-Robots-Tag']).not_to eq("none")
+  end
+
+  scenario "viewing an HMRC manual" do
+    stub_hmrc_manual
+    visit_hmrc_manual "inheritance-tax-manual"
+    expect(page.response_headers['X-Robots-Tag']).to eq("none")
+  end
+
   scenario "viewing a manual section with subsections" do
     stub_hmrc_manual
     stub_hmrc_manual_section_with_subsections


### PR DESCRIPTION
HMRC manuals on GOV.UK are not yet the canonical source. However all other manuals are, and those should be indexed by search engines so users can find them.

* Only exclude HMRC manuals from robots

cc @evilstreak @jamiecobbett @rooreynolds

Earlier attempt: https://github.com/alphagov/manuals-frontend/pull/138