### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.0'
-gem 'slimmer', '8.1.0'
+gem 'slimmer', '8.2.1'
 
 gem 'govuk_frontend_toolkit', '1.2.0'
 gem 'sass-rails', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -236,7 +236,7 @@ DEPENDENCIES
   rails (= 4.2.0)
   rspec-rails (= 3.0.2)
   sass-rails (~> 4.0.2)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)
   webmock (~> 1.17.4)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128