### PR TITLE
Use symbols, not strings, for component object keys

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,8 +16,8 @@ module ApplicationHelper
     if document.previous_sibling
       siblings.merge!( 
         previous_page: {
-          "title" => "Previous page",
-          "url" => document.previous_sibling.base_path
+          title: "Previous page",
+          url: document.previous_sibling.base_path
         }
       )
     end
@@ -25,8 +25,8 @@ module ApplicationHelper
     if document.next_sibling
       siblings.merge!(
         next_page: {
-          "title" => "Next page",
-          "url" => document.next_sibling.base_path
+          title: "Next page",
+          url: document.next_sibling.base_path
         }
       )
     end


### PR DESCRIPTION
**This shouldn't be merged until https://github.com/alphagov/static/pull/601 is merged and deployed**

**Note:** ~~I couldn't find any real manuals content with pagination to test against, so this is based on the test suite only :(~~ Tested it locally against `hmrc-internal-manuals/vat-government-and-public-bodies` and it looks OK.

We should only use one style of keys for objects used in components,
to avoid reduce confusion when using components. Consistency is good.

After discussion with @edds we agreed to use symbols as this makes
more sense in a ruby/rails environment.

The first step was to support both, as clients of those components
will still be sending string key'd objects and can't be updated
at the time as this app, so we have to;

1. [Update static components to support either strings or symbols](https://github.com/alphagov/static/pull/601)
2. Update [clients that call components with strings](https://github.com/search?utf8=%E2%9C%93&q=govuk_component%2Foption_select+OR+govuk_component%2Fprevious_and_next_navigation+repo%3Aalphagov%2Fcalendars+repo%3Aalphagov%2Fcollections+repo%3Aalphagov%2Fdesign-principles+repo%3Aalphagov%2Ffeedback+repo%3Aalphagov%2Fcourts-frontend+repo%3Aalphagov%2Fcalculators+repo%3Aalphagov%2Flicence-finder+repo%3Aalphagov%2Ffrontend+repo%3Aalphagov%2Fgovernment-frontend+repo%3Aalphagov%2Fsmart-answers+repo%3Aalphagov%2Finfo-frontend+repo%3Aalphagov%2Fcontacts-frontend+repo%3Aalphagov%2Fmanuals-frontend+repo%3Aalphagov%2Fspecialist-frontend+repo%3Aalphagov%2Ffinder-frontend+repo%3Aalphagov%2Fbusiness-support-finder+repo%3Aalphagov%2Fwhitehall+repo%3Aalphagov%2Fstatic&type=Code&ref=searchresults) to use symbols ([finder-frontend](https://github.com/alphagov/finder-frontend/pull/217) and manuals-frontend)
3. Update static to only support symbols

This PR is step 2. for `previous_and_next_navigation`, but also
needs doing in `finder-frontend` for `options_select`.

Step 1 is: https://github.com/alphagov/static/pull/601

