### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8.2'
 
 gem 'plek', '1.7.0'
-gem 'gds-api-adapters', '14.1.0'
+gem 'gds-api-adapters', '20.1.1'
 
 gem 'airbrake', '4.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,15 +65,17 @@ GEM
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (14.1.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.6.3)
+      rest-client (~> 1.8.0)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.3.0)
@@ -82,6 +84,8 @@ GEM
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     jasmine-core (2.0.0)
     jasmine-rails (0.7.0)
@@ -103,10 +107,11 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (1.25.1)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
     multi_json (1.11.1)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
@@ -121,7 +126,7 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -152,11 +157,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
-    rdoc (4.2.0)
-      json (~> 1.4)
-    rest-client (1.6.8)
-      mime-types (~> 1.16)
-      rdoc (>= 2.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-core (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.4)
@@ -206,6 +210,9 @@ GEM
     uglifier (2.5.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.2)
       kgio (~> 2.6)
       rack
@@ -225,7 +232,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
-  gds-api-adapters (= 14.1.0)
+  gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_frontend_toolkit (= 1.2.0)
   jasmine-rails


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information