### PR TITLE
Replace andSelf with addBack

### DIFF
--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -68,7 +68,7 @@
       }
 
       var subsectionBody = $subsectionHeader.nextUntil(this.superiorsSelector);
-      subsectionBody.andSelf().wrapAll('<div class="js-openable"></div>');
+      subsectionBody.addBack(el).wrapAll('<div class="js-openable"></div>');
       subsectionBody.wrapAll('<div class="js-subsection-body body-content-wrapper"></div>');
     }.bind(this));
   }


### PR DESCRIPTION
andSelf is being deprecated in future versions of jQuery, swap to using
addBack instead which is the future proof way of achieving the same
effect.