### PR TITLE
Fix header margin on small screens.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,7 +37,7 @@ main {
     }
     padding: $gutter;
     color: $white;
-    margin: 0 (-$gutter);
+    margin: 0 (-$gutter-half);
     @include core-16;
     @extend %contain-floats;
 


### PR DESCRIPTION
The blue header block had a too-large negative margin which made it bigger than its container on smaller devices, creating a horizontal scroll.

Before:

![image](https://cloud.githubusercontent.com/assets/131395/9325867/98cc34e8-458d-11e5-96d9-6ec6c20aa890.png)

After: 

![image](https://cloud.githubusercontent.com/assets/131395/9325888/b725715c-458d-11e5-949c-2e1a6422a9a1.png)
