### PR TITLE
For discussion: Disable caching for content-store

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -40,7 +40,7 @@ private
   end
 
   def manual
-    content_store.content_item(manual_base_path)
+    content_store(disable_cache: true).content_item(manual_base_path)
   end
 
   def load_manual

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -20,7 +20,7 @@ private
   end
 
   def content_store
-    GdsApi::ContentStore.new(Plek.new.find("content-store"))
+    GdsApi::ContentStore.new(Plek.new.find("content-store"), disable_cache: true)
   end
 
   def extract_parent_base_path_from_document(document)


### PR DESCRIPTION
To discuss: is this a pattern we want to generally apply? In `government-frontend`, we [explicitly pass the `cache-control` headers downstream](https://github.com/alphagov/government-frontend/blob/master/app/controllers/content_items_controller.rb#L37-L41), relying on those clients to cache the response.

We shouldn't cache content-store items in the controller requests, as this results in an inconsistency between what is published in the API and what is available to clients hitting the controllers directly.

Further to this, Rails's built-in caching is opaque to external systems, and requires a hard-restart before being cleared. This gives us no options in the future to easily propagate content-store changes to downstream clients.