### PR TITLE
Add meta description tag to manuals

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= yield :extra_headers %>
 </head>
 <body>
   <div id="global-breadcrumb" class="header-context"></div>

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <% if @manual.summary.present? %>
+    <meta name='description' content='<%= @manual.summary %>' />
+  <% end %>
+<% end %>
+
 <% content_for :title, @manual.full_title %>
 <article aria-labelledby="manual-title" id="content">
   <%= render partial: "header" %>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -42,6 +42,12 @@ feature "Viewing manuals and sections" do
     expect(page.response_headers['X-Robots-Tag']).to eq("none")
   end
 
+  scenario "viewing a manual with a description" do
+    stub_fake_manual
+    visit_manual "my-manual-about-burritos"
+    expect(page).to have_selector('meta[name="description"][content="Burrito means little donkey"]', visible: false)
+  end
+
   scenario "viewing a manual section with subsections" do
     stub_hmrc_manual
     stub_hmrc_manual_section_with_subsections


### PR DESCRIPTION
Part of improving search result snipperts shown on external search
engines. The lack of a meta-description tag makes some search result
snippets unhelpful, confusing, or misleading. Ticket:
https://trello.com/c/S6VUwRWQ/273-follow-up-add-meta-description-tag-to-custom-content-types