### PR TITLE
Remove EIM route publishing

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -40,26 +40,6 @@ namespace :publishing_api do
   task :publish_special_routes do
     logger = Logger.new(STDOUT)
 
-    publishing_api ||= GdsApi::PublishingApi.new(Plek.find("publishing-api"))
-
-    base_path = "/guidance/employment-income-manual"
-
-    gone_content_item = {
-      format: "gone",
-      content_id: "8a97dc8e-d48f-48ad-804e-862d327e1fc1",
-      update_type: "major",
-      publishing_app: "manuals-frontend",
-      routes: [
-        {
-          path: base_path,
-          type: "prefix"
-        }
-      ]
-    }
-
-    publishing_api.put_content_item(base_path, gone_content_item)
-    logger.info("Registered gone route #{gone_content_item[:content_id]}: '#{base_path}'")
-
     redirect_publisher = RedirectPublisher.new(logger: logger, publishing_app: 'manuals-frontend')
     redirect_publisher.call('09346008-7c4f-4cc4-b8d5-19d1ebf8ef5f', '/guidance', 'exact', '/government/publications')
   end


### PR DESCRIPTION
Now that a gone route for the Employment Income Manual is live, we can
remove the code which publishes this route from Manuals Frontend.