### PR TITLE
Don't strip leading slashes from the manual URL anymore

### DIFF
--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -14,10 +14,6 @@ class ManualPresenter
     true
   end
 
-  def slug_for_search
-    url[1..-1]
-  end
-
   def beta_message
     if hmrc?
       "This part of GOV.UK is still being built – you can <a href='http://www.hmrc.gov.uk/thelibrary/manuals.htm'>access the manuals from HMRC</a> in the meantime"

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -19,7 +19,7 @@
     <div class="in-manual-search">
       <form action="/search" >
         <label for="search-box">Search this manual</label>
-        <input type='hidden' name="filter_manual[]" value="<%= @manual.slug_for_search %>">
+        <input type='hidden' name="filter_manual[]" value="<%= @manual.url %>">
         <input id="search-box" type="text" name="q"/>
         <button type="submit">search</button>
       </form>


### PR DESCRIPTION
- This was used when searching within a manual as we stripped leading
  slashes on all other occurrences of the manual slug. We shouldn't do
  this anymore, because it breaks search within a manual in another way
  (which required a temporary fix in frontend).
- Trello:
  https://trello.com/c/KAR7YtA7/119-searching-within-a-manual-uses-the-wrong-layout.