### PR TITLE
Enable rich govspeak

### DIFF
--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -25,7 +25,8 @@
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= @document.collapse_depth %>>
           <div class='collapsible-subsections'>
             <%= render partial: 'govuk_component/govspeak', locals: {
-              content: @document.body
+              content: @document.body,
+              rich_govspeak: true,
             } %>
           </div>
         </div>


### PR DESCRIPTION
With the associated change in the Govspeak component, this commit
updates the call to it to set `rich_govspeak` to be `true`. This then
allows Manuals to have bold text within the body. This is required for
the Highway Code.

See https://github.com/alphagov/static/pull/657 for more information.

[Ticket](https://trello.com/c/eYyOkNRR/131-highway-code-manual-has-styled-strong-tags).