### PR TITLE
410 on updates with withdrawn manual

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -21,7 +21,11 @@ class ManualsController < ApplicationController
 private
 
   def ensure_manual_is_found
-    error_not_found unless manual
+    if manual.nil?
+      error_not_found
+    elsif manual.format == "gone"
+      error_gone
+    end
   end
 
   def ensure_document_is_found
@@ -30,6 +34,10 @@ private
 
   def error_not_found
     render status: :not_found, text: "404 error not found"
+  end
+
+  def error_gone
+    render status: :gone, text: "410 gone"
   end
 
   def manual

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -133,4 +133,12 @@ feature "Viewing manuals and sections" do
     visit_hmrc_manual_section "inheritance-tax-manual", "nonexistent-manual-section"
     expect(page.status_code).to eq(404)
   end
+
+  scenario "visiting a withdrawn manual's updates" do
+    slug = "/guidance/a-withdrawn-manual"
+    stub_withdrawn_manual(slug)
+
+    visit "#{slug}/updates"
+    expect(page.status_code).to eq(410)
+  end
 end

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -185,6 +185,17 @@ module ManualHelpers
 
     content_store_has_item("/hmrc-internal-manuals/#{manual_id}/#{section_id}", section_json)
   end
+
+  def stub_withdrawn_manual(base_path)
+
+    gone_json = {
+      base_path: base_path,
+      format: "gone",
+      phase: "live",
+    }
+
+    content_store_has_item(base_path, gone_json)
+  end
 end
 
 RSpec.configuration.include ManualHelpers


### PR DESCRIPTION
## The Problem

`/updates` does not have its own content item, so when withdrawing a Manual a `gone` content item is published for the Manual and each of its sections but not `#{manual_slug}/updates`. When a User views `/updates` on a withdrawn Manual, Manuals Frontend will try to render the page with the `gone` content item that it has for the withdrawn Manual.

When that happens, the App will 500 and this will fall over to the cache, which has the `/updates` page cached and displays it.

## The solution

Don't return a `content_item` for the Manual if it has a format of `gone`, allowing the App to 410 as would be expected.

This PR does just that and adds a failing test for this edgecase.