### PR TITLE
Upgrade Slimmer, explicitly set layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.2'
-gem 'slimmer', '8.2.1'
+gem 'slimmer', '9.0.0'
 
 gem 'govuk_frontend_toolkit', '1.2.0'
 gem 'sass-rails', '~> 4.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -243,7 +243,7 @@ DEPENDENCIES
   rails (= 4.2.2)
   rspec-rails (= 3.0.2)
   sass-rails (~> 4.0.2)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)
   webmock (~> 1.17.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
+  include Slimmer::Template
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -12,7 +13,7 @@ class ApplicationController < ActionController::Base
   private
 
   def slimmer_headers
-    set_slimmer_headers(template: "header_footer_only")
+    slimmer_template "header_footer_only"
     set_slimmer_headers(remove_search: true)
   end
 end


### PR DESCRIPTION
This is a no-op change to app behaviour. The same Slimmer layout is used as be
before, but set in a simple, standardised way with `slimmer_template`, which is
easier to grep for than the other methods.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

Switching to core looks like it would be straightforward, removing the use of
`.inner-block` to set the base grid, but i'd want to do that in a separate PR.

[1] https://github.com/alphagov/slimmer/pull/136