### PR TITLE
Fix internal anchor links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,7 @@ jQuery(function($) {
 
   $('.govspeak').on('click', 'a', function(event){
     if (window.location.pathname == event.target.pathname) {
-      openSectionContainingAnchor($(window.location.hash));
+      openSectionContainingAnchor($(event.currentTarget.hash));
     }
   })
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,21 +9,4 @@ jQuery(function($) {
   $('.js-collapsible-collection').each(function(){
     new GOVUK.CollapsibleCollection({$el:$(this)});
   })
-
-  if (window.location.hash) {
-    openSectionContainingAnchor($(window.location.hash));
-  }
-
-  $('.govspeak').on('click', 'a', function(event){
-    if (window.location.pathname == event.target.pathname) {
-      openSectionContainingAnchor($(event.currentTarget.hash));
-    }
-  })
 });
-
-
-function openSectionContainingAnchor($anchor) {
-  if ($anchor.length != 0) {
-    new GOVUK.Collapsible($anchor.closest('.js-openable')).open();
-  }
-}

--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -29,7 +29,17 @@
         this.collapsibles[openSectionID].open();
       }
 
+      if (window.location.hash) {
+        this.openSectionContainingAnchor($(window.location.hash));
+      }
+
       this.$container.on('click', 'a[rel="footnote"]', this.expandFootnotes.bind(this));
+
+      this.$container.on('click', 'a', function(event){
+        if (window.location.pathname === event.target.pathname) {
+          this.openSectionContainingAnchor($(event.currentTarget.hash));
+        }
+      }.bind(this))
     }
   }
 
@@ -157,6 +167,12 @@
 
   CollapsibleCollection.prototype.enableControl = function enableControl(control){
     control.removeClass('disabled');
+  }
+
+  CollapsibleCollection.prototype.openSectionContainingAnchor = function openSectionContainingAnchor($anchor){
+    if ($anchor.length !== 0) {
+      new GOVUK.Collapsible($anchor.closest('.js-openable')).open();
+    }
   }
 
   GOVUK.CollapsibleCollection = CollapsibleCollection;

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -34,21 +34,7 @@ describe('CollapsibleCollection', function(){
     collectionsFromBlobHTML.remove();
   });
 
-
-  describe('initCollapsible', function(){
-    it ('should add control links to HTML generated from a blob', function(){
-      var html = $(collectionsFromBlobString);
-      expect(html.find('a.collection-control').length).toBe(0);
-      var newCollection = new GOVUK.CollapsibleCollection({$el:html});
-      expect(newCollection.$container.find('.js-collection-controls a').length).toBe(2);
-    });
-
-    it('should add a new object to collapsibles hash with the id from the section for blobs', function(){
-      var collectionSize = Object.keys(collection.collapsibles).length;
-      collection.initCollapsible(collection.$sections[0]);
-      expect(Object.keys(collection.collapsibles).length).toBe(collectionSize+1);
-    });
-
+  describe('CollapsibleCollection', function(){
     it('should close all sections by default', function(){
       spyOn(GOVUK, 'getCurrentLocation').and.returnValue({
         hash: ''
@@ -90,6 +76,24 @@ describe('CollapsibleCollection', function(){
 
       expect(openSections.length).toBe(1);
       expect(openSections[0]).toBe(collection.collapsibles['a-second-section-title']);
+    });
+  });
+
+  describe('initCollapsible', function(){
+    it ('should add control links to HTML generated from a blob', function(){
+      var html = $(collectionsFromBlobString);
+      expect(html.find('a.collection-control').length).toBe(0);
+      var newCollection = new GOVUK.CollapsibleCollection({$el:html});
+      expect(newCollection.$container.find('.js-collection-controls a').length).toBe(2);
+    });
+
+    it('should add a new object to collapsibles hash with the id from the section for blobs', function(){
+      var collection = new GOVUK.CollapsibleCollection({
+        $el: collectionsFromBlobHTML
+      });
+      var collectionSize = Object.keys(collection.collapsibles).length;
+      collection.initCollapsible(collection.$sections[0]);
+      expect(Object.keys(collection.collapsibles).length).toBe(collectionSize+1);
     });
   });
 

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -27,22 +27,30 @@ describe('CollapsibleCollection', function(){
       collectionsFromBlobHTML = $(collectionsFromBlobString);
 
       $('body').append(collectionsFromBlobHTML);
-      collection = new GOVUK.CollapsibleCollection({$el:collectionsFromBlobHTML});
+      collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
   });
 
   afterEach(function(){
     collectionsFromBlobHTML.remove();
   });
 
+  var resetBody = function resetBody() {
+    collectionsFromBlobHTML.remove();
+    collectionsFromBlobHTML = $(collectionsFromBlobString);
+    $('body').append(collectionsFromBlobHTML);
+  };
+
   describe('CollapsibleCollection', function(){
+    beforeEach(function(){
+      resetBody();
+    });
+
     it('should close all sections by default', function(){
       spyOn(GOVUK, 'getCurrentLocation').and.returnValue({
         hash: ''
       });
 
-      var collection = new GOVUK.CollapsibleCollection({
-        $el: collectionsFromBlobHTML
-      });
+      var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
 
       var sections = $.map(
         collection.collapsibles,
@@ -61,9 +69,7 @@ describe('CollapsibleCollection', function(){
         hash: '#a-second-section-title'
       });
 
-      var collection = new GOVUK.CollapsibleCollection({
-        $el: collectionsFromBlobHTML
-      });
+      var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
 
       var sections = $.map(
         collection.collapsibles,
@@ -83,14 +89,11 @@ describe('CollapsibleCollection', function(){
     it ('should add control links to HTML generated from a blob', function(){
       var html = $(collectionsFromBlobString);
       expect(html.find('a.collection-control').length).toBe(0);
-      var newCollection = new GOVUK.CollapsibleCollection({$el:html});
-      expect(newCollection.$container.find('.js-collection-controls a').length).toBe(2);
+      var collection = new GOVUK.CollapsibleCollection({$el:html});
+      expect(collection.$container.find('.js-collection-controls a').length).toBe(2);
     });
 
     it('should add a new object to collapsibles hash with the id from the section for blobs', function(){
-      var collection = new GOVUK.CollapsibleCollection({
-        $el: collectionsFromBlobHTML
-      });
       var collectionSize = Object.keys(collection.collapsibles).length;
       collection.initCollapsible(collection.$sections[0]);
       expect(Object.keys(collection.collapsibles).length).toBe(collectionSize+1);
@@ -116,11 +119,9 @@ describe('CollapsibleCollection', function(){
     });
 
     it('should wrap all tags following a js-subsection-title h2 up to the next js-subsection-title h2 in a div with the class js-subsection-body', function(){
-
       collectionsFromBlobHTML.find('h2.js-subsection-title').each(function(index){
         expect($(this).next().hasClass('js-subsection-body')).toBe(true);
       });
-
     });
   });
 
@@ -221,7 +222,6 @@ describe('CollapsibleCollection', function(){
 
       expect(collection.disableControl).toHaveBeenCalledWith(collection.$openAll);
     });
-
   });
 });
 

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -36,6 +36,13 @@ describe('CollapsibleCollection', function(){
     collectionsFromBlobHTML.remove();
   });
 
+  var findOpenSections = function openSections(collapsibles) {
+    return $.map(
+      collapsibles,
+      function(section, index) { return section.isClosed() ? null : section; }
+    );
+  };
+
   var resetBody = function resetBody() {
     collectionsFromBlobHTML.remove();
     collectionsFromBlobHTML = $(collectionsFromBlobString);
@@ -54,14 +61,7 @@ describe('CollapsibleCollection', function(){
 
       var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
 
-      var sections = $.map(
-        collection.collapsibles,
-        function(section, index) { return section; }
-      );
-
-      var openSections = sections.filter(
-        function(section) { return !section.isClosed(); }
-      );
+      var openSections = findOpenSections(collection.collapsibles);
 
       expect(openSections.length).toBe(0);
     });
@@ -73,32 +73,18 @@ describe('CollapsibleCollection', function(){
 
       var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
 
-      var sections = $.map(
-        collection.collapsibles,
-        function(section, index) { return section; }
-      );
-
-      var openSections = sections.filter(
-        function(section) { return !section.isClosed(); }
-      );
+      var openSections = findOpenSections(collection.collapsibles);
 
       expect(openSections.length).toBe(1);
       expect(openSections[0]).toBe(collection.collapsibles['a-second-section-title']);
     });
 
-    it('should open the section linked to by the anchor on the same page', function(){
+    it('should open the closed section linked to by the anchor on the same page', function(){
       var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
 
       $('#internal-link').click();
 
-      var sections = $.map(
-        collection.collapsibles,
-        function(section, index) { return section; }
-      );
-
-      var openSections = sections.filter(
-        function(section) { return !section.isClosed(); }
-      );
+      var openSections = findOpenSections(collection.collapsibles);
 
       expect(openSections.length).toBe(1);
       expect(openSections[0]).toBe(collection.collapsibles['a-section-title']);

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -14,12 +14,14 @@ describe('CollapsibleCollection', function(){
             '<p>Where the tax gets paid to the man about the thing for the other thing</p>'+
             // Three collapsible subsections
             '<h2 id="a-section-title">A section title!</h2>'+
+            '<h3 id="a-sub-section-title">A subsection title!</h3>'+
             '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
             '<h2 id="a-second-section-title">A second section title!</h2>'+
             '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
             '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
             '<h2 id="a-third-section-title">A third section title!</h2>'+
             '<p>Where an employer meets the tax payable on a non-cash incentive award given to a direct</p>'+
+            '<p>Follow this <a id="internal-link" href="#a-sub-section-title">Link to subsection in first section</a></p>'+
           '</div>'+
         '</div>'+
       '</div>';
@@ -82,6 +84,24 @@ describe('CollapsibleCollection', function(){
 
       expect(openSections.length).toBe(1);
       expect(openSections[0]).toBe(collection.collapsibles['a-second-section-title']);
+    });
+
+    it('should open the section linked to by the anchor on the same page', function(){
+      var collection = new GOVUK.CollapsibleCollection({$el: collectionsFromBlobHTML});
+
+      $('#internal-link').click();
+
+      var sections = $.map(
+        collection.collapsibles,
+        function(section, index) { return section; }
+      );
+
+      var openSections = sections.filter(
+        function(section) { return !section.isClosed(); }
+      );
+
+      expect(openSections.length).toBe(1);
+      expect(openSections[0]).toBe(collection.collapsibles['a-section-title']);
     });
   });
 


### PR DESCRIPTION
For https://trello.com/c/E6u89QxG/132-fix-manuals-linking-issue

Fixes the issue of clicking on a link (that links to another section within the same manual) not opening the appropriate section. The fix itself is just changing one line, but in order to write test for it, the code was refactored.