### PR TITLE
Fix multiple creation of close spans

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,5 +8,5 @@ jQuery(function($) {
 
   $('.js-collapsible-collection').each(function(){
     new GOVUK.CollapsibleCollection({$el:$(this)});
-  })
+  });
 });

--- a/app/assets/javascripts/collapsible.js
+++ b/app/assets/javascripts/collapsible.js
@@ -10,26 +10,26 @@
   }
 
   Collapsible.prototype.addToggle = function addToggle(){
-    var $toggleHTML = $("<span class='js-toggle'></span>")
+    var $toggleHTML = $("<span class='js-toggle'></span>");
     this.$clickTarget.append($toggleHTML);
-  }
+  };
 
   Collapsible.prototype.toggle = function toggle(event){
     this.$section.toggleClass('closed');
     event.preventDefault();
-  }
+  };
 
   Collapsible.prototype.close = function close(){
     this.$section.addClass('closed');
-  }
+  };
 
   Collapsible.prototype.open = function open(){
     this.$section.removeClass('closed');
-  }
+  };
 
   Collapsible.prototype.isClosed = function(){
     return this.$section.hasClass('closed');
-  }
+  };
 
   GOVUK.Collapsible = Collapsible;
 }());

--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -18,7 +18,7 @@
 
     if(this.$sections.length > 0) {
       this.$sections.each(this.initCollapsible.bind(this));
-      this.$openAll = $("<a href='#' aria-hidden=true>Open all</a>"),
+      this.$openAll = $("<a href='#' aria-hidden=true>Open all</a>");
       this.$closeAll = $("<a href='#' aria-hidden=true>Close all</a>");
       this.addControls();
 
@@ -35,7 +35,7 @@
         if (window.location.pathname === event.target.pathname) {
           this.openCollapsibleForAnchor(event.currentTarget.hash);
         }
-      }.bind(this))
+      }.bind(this));
     }
   }
 
@@ -50,11 +50,11 @@
 
     $section.on('click', this.updateControls.bind(this));
     this.collapsibles[sectionID] = collapsible;
-  }
+  };
 
   CollapsibleCollection.prototype.expandFootnotes = function expandFootnotes(){
-    this.collapsibles['footnotes'].open();
-  }
+    this.collapsibles.footnotes.open();
+  };
 
   CollapsibleCollection.prototype.markupSections = function markupSections(){
     // Pull out h2's and mark them up as js-subsection-title.
@@ -77,7 +77,7 @@
       subsectionBody.andSelf().wrapAll('<div class="js-openable"></div>');
       subsectionBody.wrapAll('<div class="js-subsection-body body-content-wrapper"></div>');
     }.bind(this));
-  }
+  };
 
   CollapsibleCollection.prototype.calculateSuperiorsSelector = function calculateSuperiorsSelector(depth){
     // Returns a string with this header and all the headers of higher priority, for example 'h2,h1' (depth is zero offset)
@@ -91,7 +91,7 @@
     }
     selector = selector.slice(0,-1);
     return selector;
-  }
+  };
 
   CollapsibleCollection.prototype.closeAll = function closeAll(event){
     for (var section in this.collapsibles) {
@@ -104,7 +104,7 @@
     if (typeof event != 'undefined'){
       event.preventDefault();
     }
-  }
+  };
 
   CollapsibleCollection.prototype.openAll = function openAll(event){
     for (var section in this.collapsibles) {
@@ -117,7 +117,7 @@
     if (typeof event != 'undefined'){
       event.preventDefault();
     }
-  }
+  };
 
   CollapsibleCollection.prototype.addControls = function addControls(){
     var $collectionControlsWrap = $('<div class="js-title-controls-wrap"/>');
@@ -134,14 +134,14 @@
     this.$container.prepend($collectionControlsWrap);
     this.$openAll.on('click', this.openAll.bind(this));
     this.$closeAll.on('click', this.closeAll.bind(this));
-  }
+  };
 
   CollapsibleCollection.prototype.updateControls = function updateControls(){
     // if all the sections in this collection are open
     var sectionCount = this.$sections.length;
     var closedCount = this.$container.find('.closed').length;
 
-    if (closedCount == 0) {
+    if (closedCount === 0) {
       // all the sections are open
       this.disableControl(this.$openAll);
       this.enableControl(this.$closeAll);
@@ -155,22 +155,22 @@
       this.enableControl(this.$openAll);
       this.enableControl(this.$closeAll);
     }
-  }
+  };
 
   CollapsibleCollection.prototype.disableControl = function disableControl(control){
     control.addClass('disabled');
-  }
+  };
 
   CollapsibleCollection.prototype.enableControl = function enableControl(control){
     control.removeClass('disabled');
-  }
+  };
 
   CollapsibleCollection.prototype.openCollapsibleForAnchor = function openCollapsibleForAnchor(anchor){
     var collapsible = this.getCollapsibleFromSection(anchor) || this.getCollapsibleFromAnchorInSection(anchor);
     if (collapsible) {
       collapsible.open();
     }
-  }
+  };
 
   CollapsibleCollection.prototype.getCollapsibleFromSection = function getCollapsibleFromSection(anchor){
     var collapsible = null;
@@ -179,9 +179,9 @@
         collapsible = _collapsible;
         return false;
       }
-    })
+    });
     return collapsible;
-  }
+  };
 
   CollapsibleCollection.prototype.getCollapsibleFromAnchorInSection = function getCollapsibleFromAnchorInSection(anchor){
     var section = $(anchor).closest('.js-openable')[0];
@@ -192,9 +192,9 @@
         collapsible = _collapsible;
         return false;
       }
-    })
+    });
     return collapsible;
-  }
+  };
 
   GOVUK.CollapsibleCollection = CollapsibleCollection;
 }());

--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -24,20 +24,16 @@
 
       this.closeAll();
 
-      var openSectionID = GOVUK.getCurrentLocation().hash.substr(1);
-      if(typeof(this.collapsibles[openSectionID]) != 'undefined') {
-        this.collapsibles[openSectionID].open();
-      }
-
-      if (window.location.hash) {
-        this.openSectionContainingAnchor($(window.location.hash));
+      var anchor = GOVUK.getCurrentLocation().hash;
+      if (anchor) {
+        this.openCollapsibleForAnchor(anchor);
       }
 
       this.$container.on('click', 'a[rel="footnote"]', this.expandFootnotes.bind(this));
 
       this.$container.on('click', 'a', function(event){
         if (window.location.pathname === event.target.pathname) {
-          this.openSectionContainingAnchor($(event.currentTarget.hash));
+          this.openCollapsibleForAnchor(event.currentTarget.hash);
         }
       }.bind(this))
     }
@@ -169,10 +165,35 @@
     control.removeClass('disabled');
   }
 
-  CollapsibleCollection.prototype.openSectionContainingAnchor = function openSectionContainingAnchor($anchor){
-    if ($anchor.length !== 0) {
-      new GOVUK.Collapsible($anchor.closest('.js-openable')).open();
+  CollapsibleCollection.prototype.openCollapsibleForAnchor = function openCollapsibleForAnchor(anchor){
+    var collapsible = this.getCollapsibleFromSection(anchor) || this.getCollapsibleFromAnchorInSection(anchor);
+    if (collapsible) {
+      collapsible.open();
     }
+  }
+
+  CollapsibleCollection.prototype.getCollapsibleFromSection = function getCollapsibleFromSection(anchor){
+    var collapsible = null;
+    $.each(this.collapsibles, function (key, _collapsible) {
+      if (key === anchor.substr(1)) {
+        collapsible = _collapsible;
+        return false;
+      }
+    })
+    return collapsible;
+  }
+
+  CollapsibleCollection.prototype.getCollapsibleFromAnchorInSection = function getCollapsibleFromAnchorInSection(anchor){
+    var section = $(anchor).closest('.js-openable')[0];
+
+    var collapsible = null;
+    $.each(this.collapsibles, function (key, _collapsible) {
+      if (_collapsible.$section[0] === section) {
+        collapsible = _collapsible;
+        return false;
+      }
+    })
+    return collapsible;
   }
 
   GOVUK.CollapsibleCollection = CollapsibleCollection;

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -110,7 +110,7 @@ describe('CollapsibleCollection', function(){
     it('should add the a js-subsection-title class to any h2s that are not excluded by js-exclude-h2s or have the link-out class for blobs', function(){
       var html = $(collectionsFromBlobString);
       var h2Count = html.find('h2').length;
-      var excludedH2Count = html.find('.js-ignore-h2s h2, h2.linked-title').length
+      var excludedH2Count = html.find('.js-ignore-h2s h2, h2.linked-title').length;
       var sectionHeaderCount = h2Count - excludedH2Count;
 
       expect(html.find('h2.js-subsection-title').length).toBe(0);
@@ -143,12 +143,12 @@ describe('CollapsibleCollection', function(){
       collection.openAll();
 
       for (var collapsible_id in this.collapsibles) {
-        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(false)
+        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(false);
       }
       collection.closeAll();
 
       for (var collapsible_id in this.collapsibles) {
-        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(true)
+        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(true);
       }
     });
 
@@ -170,12 +170,12 @@ describe('CollapsibleCollection', function(){
       collection.closeAll();
 
       for (var collapsible_id in this.collapsibles) {
-        expect($(this.collapsible[collapsible.id]).isOpen()).toBe(false)
+        expect($(this.collapsible[collapsible.id]).isOpen()).toBe(false);
       }
       collection.openAll();
 
       for (var collapsible_id in this.collapsibles) {
-        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(true)
+        expect($(this.collapsible[collapsible.id]).isClosed()).toBe(true);
       }
     });
 

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -229,5 +229,51 @@ describe('CollapsibleCollection', function(){
       expect(collection.disableControl).toHaveBeenCalledWith(collection.$openAll);
     });
   });
-});
 
+  describe('openCollapsibleForAnchor', function(){
+    it ('should open the collapsible for the given section title', function(){
+      spyOn(collection, "getCollapsibleFromSection").and.returnValue(collection.collapsibles['a-third-section-title']);
+      collection.openCollapsibleForAnchor('#a-third-section-title');
+
+      var openSections = findOpenSections(collection.collapsibles);
+
+      expect(openSections.length).toBe(1);
+      expect(openSections[0]).toBe(collection.collapsibles['a-third-section-title']);
+    });
+
+    it ('should open the collapsible for the given anchor within a section', function(){
+      spyOn(collection, "getCollapsibleFromSection").and.returnValue(null);
+      spyOn(collection, "getCollapsibleFromAnchorInSection").and.returnValue(collection.collapsibles['a-section-title']);
+      collection.openCollapsibleForAnchor('#a-sub-section-title');
+
+      var openSections = findOpenSections(collection.collapsibles);
+
+      expect(openSections.length).toBe(1);
+      expect(openSections[0]).toBe(collection.collapsibles['a-section-title']);
+    });
+
+    it ('should not open any collapsible if collapsible cannot be found', function(){
+      spyOn(collection, "getCollapsibleFromSection").and.returnValue(null);
+      spyOn(collection, "getCollapsibleFromAnchorInSection").and.returnValue(null);
+      collection.openCollapsibleForAnchor('#some-non-existant-section-title');
+
+      var openSections = findOpenSections(collection.collapsibles);
+
+      expect(openSections.length).toBe(0);
+    });
+  });
+
+  describe('getCollapsibleFromSection', function(){
+    it ('should find the collapsible for the given section title', function(){
+      var collapsible = collection.getCollapsibleFromSection('#a-third-section-title');
+      expect(collapsible).toBe(collection.collapsibles['a-third-section-title']);
+    });
+  });
+
+  describe('getCollapsibleFromAnchorInSection', function(){
+    it ('should find the collapsible for the given anchor in a section', function(){
+      var collapsible = collection.getCollapsibleFromAnchorInSection('#a-sub-section-title');
+      expect(collapsible).toBe(collection.collapsibles['a-section-title']);
+    });
+  });
+});

--- a/spec/javascripts/collapsible_spec.js
+++ b/spec/javascripts/collapsible_spec.js
@@ -64,12 +64,12 @@ describe('Collapsible', function(){
   describe('isClosed', function(){
     it('should return true if the collapsible has the class "closed"', function(){
       collapsible.$section.addClass('closed');
-      expect(collapsible.isClosed()).toBe(true)
+      expect(collapsible.isClosed()).toBe(true);
     });
 
     it('should return false if the collapsible doesnt have the class "closed"', function(){
       collapsible.$section.removeClass('closed');
-      expect(collapsible.isClosed()).toBe(false)
+      expect(collapsible.isClosed()).toBe(false);
     });
 
   });


### PR DESCRIPTION
This fixes an issue for when a Collapsible would be opened by clicking on a link to it, a new Collapsible was created for it. In practice this meant that a collapsible could have an increasing number of clickable spans, which lead to unexpected such as a click not appearing to open a span (while actually the click was triggering the toggle open action twice, thereby opening and immediately closing the Collapsible). As part of the fix, some functionality was extracted to separate methods and respective Jasmine tests have been added.