### PR TITLE
Remove beta_message from ManualPresenter

### DIFF
--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -14,12 +14,6 @@ class ManualPresenter
     true
   end
 
-  def beta_message
-    if hmrc?
-      "This part of GOV.UK is still being built – you can <a href='http://www.hmrc.gov.uk/thelibrary/manuals.htm'>access the manuals from HMRC</a> in the meantime"
-    end
-  end
-
   def full_title
     if hmrc?
       @manual.title + ' - HMRC internal manual'

--- a/app/views/manuals/_beta_label.html.erb
+++ b/app/views/manuals/_beta_label.html.erb
@@ -1,5 +1,0 @@
-<% if manual.beta_message %>
-  <%= render partial: 'govuk_component/beta_label', locals: { message: manual.beta_message } %>
-<% else %>
-  <%= render partial: 'govuk_component/beta_label' %>
-<% end %>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,5 +1,5 @@
 <% if @manual.beta? %>
-  <%= render partial: 'beta_label', locals: { manual: @manual } %>
+  <%= render partial: 'govuk_component/beta_label' %>
 <% end %>
 <header aria-labelledby="manual-title" class="<%= @manual.hmrc? ? 'hmrc' : nil %>">
   <div class='primary'>


### PR DESCRIPTION
We no longer want to provide a special message in the beta label for HMRC
content as the only manuals of theirs published here are not available in
their library.

For: https://trello.com/c/ZSSTBlqM/245-change-the-beta-label-on-hmrc-manuals