### PR TITLE
Update manual presenter to prefer links for organisation data

### DIFF
--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -33,7 +33,7 @@ class ManualPresenter
   end
 
   def organisations
-    @manual.details.organisations || []
+    @manual.links.organisations || @manual.details.organisations || []
   end
 
   def hmrc?

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -4,16 +4,10 @@ require 'govuk-content-schema-test-helpers'
 module ManualHelpers
   include GdsApi::TestHelpers::ContentStore
 
-  def hmrc_links
-    {
-      organisations: [
-        {
-          abbreviation: "HMRC",
-          web_url: "http://www.gov.uk/government/organisations/hm-revenue-customs",
-          title: "HM Revenue & Customs",
-        }
-      ]
-    }
+  def example_hmrc_links
+    JSON.parse(
+      GovukContentSchemaTestHelpers::Examples.new.get('hmrc_manual', 'vat-government-public-bodies')
+    ).fetch("links")
   end
 
   def stub_fake_manual
@@ -84,7 +78,7 @@ module ManualHelpers
       description: nil,
       format: "manual",
       public_updated_at: "2014-01-23T00:00:00+01:00",
-      links: hmrc_links,
+      links: example_hmrc_links,
       details: {
         child_section_groups: [
           {
@@ -129,7 +123,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
-      links: hmrc_links,
+      links: example_hmrc_links,
       details: {
         body: nil,
         section_id: "EIM00500",
@@ -171,7 +165,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
-      links: hmrc_links,
+      links: example_hmrc_links,
       details: {
         breadcrumbs: [
           {
@@ -198,7 +192,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
-      links: hmrc_links,
+      links: example_hmrc_links,
       details: {
         body: 'On this page:<br><br><a href="/hmrc-internal-manuals/#{manual_id}/#{section_id}#EIM15010#IDAZR1YH">Sections 386-400 ITEPA 2003]</a><br>',
         section_id: "#{section_id}",

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -10,6 +10,12 @@ module ManualHelpers
     ).fetch("links")
   end
 
+  def example_links
+    JSON.parse(
+      GovukContentSchemaTestHelpers::Examples.new.get('manual', 'content-design')
+    ).fetch("links")
+  end
+
   def stub_fake_manual
     manual_json = {
       base_path: "/guidance/my-manual-about-burritos",
@@ -17,15 +23,7 @@ module ManualHelpers
       description: "Burrito means little donkey",
       format: "manual",
       public_updated_at: "2014-06-20T10:17:29+01:00",
-      links: {
-        organisations: [
-          {
-            abbreviation: "CO",
-            web_url: "http://www.gov.uk/government/organisations/cabinet-office",
-            title: "Cabinet Office",
-          }
-        ]
-      },
+      links: example_links,
       details: {
         child_section_groups: [
           {

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -1,7 +1,20 @@
 require 'gds_api/test_helpers/content_store'
+require 'govuk-content-schema-test-helpers'
 
 module ManualHelpers
   include GdsApi::TestHelpers::ContentStore
+
+  def hmrc_links
+    {
+      organisations: [
+        {
+          abbreviation: "HMRC",
+          web_url: "http://www.gov.uk/government/organisations/hm-revenue-customs",
+          title: "HM Revenue & Customs",
+        }
+      ]
+    }
+  end
 
   def stub_fake_manual
     manual_json = {
@@ -10,6 +23,15 @@ module ManualHelpers
       description: "Burrito means little donkey",
       format: "manual",
       public_updated_at: "2014-06-20T10:17:29+01:00",
+      links: {
+        organisations: [
+          {
+            abbreviation: "CO",
+            web_url: "http://www.gov.uk/government/organisations/cabinet-office",
+            title: "Cabinet Office",
+          }
+        ]
+      },
       details: {
         child_section_groups: [
           {
@@ -62,6 +84,7 @@ module ManualHelpers
       description: nil,
       format: "manual",
       public_updated_at: "2014-01-23T00:00:00+01:00",
+      links: hmrc_links,
       details: {
         child_section_groups: [
           {
@@ -106,6 +129,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
+      links: hmrc_links,
       details: {
         body: nil,
         section_id: "EIM00500",
@@ -147,6 +171,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
+      links: hmrc_links,
       details: {
         breadcrumbs: [
           {
@@ -173,6 +198,7 @@ module ManualHelpers
       description: nil,
       format: "manual-section",
       public_updated_at: "2014-01-23T00:00:00+01:00",
+      links: hmrc_links,
       details: {
         body: 'On this page:<br><br><a href="/hmrc-internal-manuals/#{manual_id}/#{section_id}#EIM15010#IDAZR1YH">Sections 386-400 ITEPA 2003]</a><br>',
         section_id: "#{section_id}",


### PR DESCRIPTION
We're currently updating apps to support a new tagging architecture.
Part of this work includes changes to hmrc-manuals-api such that it sets
the organisation data in the links hash rather than the details hash.

This change to manuals-frontend ensures organisation data in the links
field of the manual payload is used in preference to data in details.
This will eventually be updated to drop usage of details altogether.

Trello: https://trello.com/c/6Owhx9Vn