### PR TITLE
Update HMRC manual URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Front-end app for the manuals format on GOV.UK
 ## Live examples
 
 - [gov.uk/guidance/content-design](https://www.gov.uk/guidance/content-design)
-- [gov.uk/hmrc-internal-manuals/vat-government-and-public-bodies](https://www.gov.uk/hmrc-internal-manuals/vat-government-and-public-bodies)
+- [gov.uk/hmrc-internal-manuals/pensions-tax-manual](https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual)
 
 ## Nomenclature
 


### PR DESCRIPTION
The old URL has been removed. Use an alternative.

https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual