### PR TITLE
Add HTTP caching

### DIFF
--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -17,6 +17,7 @@ feature "Viewing manuals and sections" do
     expect_title_tag_to_be('Inheritance Tax Manual - HMRC internal manual - GOV.UK')
     expect_manual_title_to_be("Inheritance Tax Manual")
     expect_manual_update_date_to_be("23 January 2014")
+    expect(page.response_headers["Cache-Control"]).to eq("max-age=900, public")
 
     # This next expectation has been temporarily disabled until inline rendering of leaf
     # sections is implemented
@@ -65,6 +66,8 @@ feature "Viewing manuals and sections" do
                                    href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00520")
     expect_page_to_include_section("Particular items: R to Z",
                                    href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00530")
+
+    expect(page.response_headers["Cache-Control"]).to eq("max-age=1200, private")
 
     # breadcrumb
     expect(page).to have_link("Contents",

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -111,7 +111,11 @@ module ManualHelpers
       }
     }
 
-    content_store_has_item("/hmrc-internal-manuals/#{manual_id}", manual_json)
+    content_store_has_item(
+      "/hmrc-internal-manuals/#{manual_id}",
+      manual_json,
+      { max_age: 15.minutes.to_i },
+    )
   end
 
   def stub_hmrc_manual_section_with_subsections
@@ -153,7 +157,11 @@ module ManualHelpers
       }
     }
 
-    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00500", section_json)
+    content_store_has_item(
+      "/hmrc-internal-manuals/inheritance-tax-manual/eim00500",
+      section_json,
+      { max_age: 20.minutes.to_i, private: true },
+    )
   end
 
   def stub_hmrc_manual_sub_sub_section


### PR DESCRIPTION
For https://trello.com/c/pl3zZeWr/257-add-caching-to-manuals-frontend

Manuals-frontend previously did not set any caching, so Rails by default prevents any caching (setting `Cache-Control: max-age=0, private, must-revalidate`).

This implementation is inspired by [`government-frontend`'s implementation of the `set_expiry` method](https://github.com/alphagov/government-frontend/commit/fe66f96c238be1c751c49f54871e2ffec93edcc6), setting cache headers based on the content items that are being presented.
