### PR TITLE
Remove invalid breadcrumbs aria role

### DIFF
--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -33,7 +33,7 @@
     </div>
   </div>
 </header>
-<ol class='breadcrumb-trail' role='breadcrumbs'>
+<ol class='breadcrumb-trail'>
   <% if request.path == @manual.url %>
     <li class="no-separator">Contents</li>
   <% else %>


### PR DESCRIPTION
`role="breadcrumbs"` is not a thing.
https://www.w3.org/TR/wai-aria/roles#role_definitions

We previously removed from the component: https://github.com/alphagov/static/pull/737
Was added in: https://github.com/alphagov/manuals-frontend/pull/4