### PR TITLE
Configure logstasher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'plek', '1.11.0'
 gem 'gds-api-adapters', '26.7.0'
 
 gem 'airbrake', '4.0.0'
+gem 'logstasher', '0.6.2'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
     launchy (2.4.2)
       addressable (~> 2.3)
     link_header (0.0.8)
+    logstash-event (1.1.5)
+    logstasher (0.6.2)
+      logstash-event (~> 1.1.0)
+      request_store
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)
@@ -159,6 +163,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (11.2.2)
+    request_store (1.3.1)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -239,6 +244,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 1.2.0)
   jasmine-rails
   launchy
+  logstasher (= 0.6.2)
   plek (= 1.11.0)
   poltergeist (= 1.5.0)
   pry

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,11 @@ ManualsFrontend::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Logstasher config
+  $real_stdout = $stdout.clone
+  $stdout.reopen($stderr)
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new($real_stdout)
+  config.logstasher.suppress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+    # Pass request Id to logging
+    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+  end
+end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1414121

Manuals frontend is generating a lot of uninformative logging. As a first step to remedying this configure it to use logstasher and turn off application logs. I've based this on examples found in government-frontend, specialist-publisher-rebuild and publishing-api.