### PR TITLE
Turn off view logging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,5 +88,6 @@ ManualsFrontend::Application.configure do
   $stdout.reopen($stderr)
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new($real_stdout)
+  config.logstasher.view_enabled = false
   config.logstasher.suppress_app_log = true
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1414121
This config option switches off view logging which should reduce
the volume of useless log lines containing 'rendered foo/bar.erb...'