### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -1,3 +1,9 @@
+<% content_for :extra_headers do %>
+  <% if @manual.summary.present? %>
+    <meta name='description' content='<%= @manual.summary %>' />
+  <% end %>
+<% end %>
+
 <% content_for :title, @document.full_title %>
 <%= render partial: "header" %>
 <div class='manual-body' id="content">

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -1,3 +1,7 @@
+<% content_for :extra_headers do %>
+  <meta name='description' content="List of updates to '<%= @manual.full_title %>'." />
+<% end %>
+
 <% content_for :title, 'Updates - ' + @manual.full_title %>
 <%= render partial: "header" %>
 <div class='manual-body' id="content">


### PR DESCRIPTION
The meta description tag is used for the index page of a manual but none of the sub-pages. This commit adds meta description tags to all pages, the contents of which are set to the description associated with the manual. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them