### PR TITLE
Remove beta label from normal manuals, leave it for HMRC

### DIFF
--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -6,12 +6,8 @@ class ManualPresenter
   end
 
   def beta?
-    # At some point some of the manuals will be in beta and some won't and we'll need to
-    # check that here and return true/fase accordingly. Punting that work into the future
-    # for now as I don't have time to do it before the Show The Thing deadline in two day's
-    # time.
-
-    true
+    # HMRC manuals are still in beta, others are not
+    hmrc?
   end
 
   def full_title

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -35,12 +35,14 @@ feature "Viewing manuals and sections" do
     stub_fake_manual
     visit_manual "my-manual-about-burritos"
     expect(page.response_headers['X-Robots-Tag']).not_to eq("none")
+    expect(page).not_to have_selector('test-govuk-component[data-template="govuk_component-beta_label"]')
   end
 
   scenario "viewing an HMRC manual" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
     expect(page.response_headers['X-Robots-Tag']).to eq("none")
+    expect(page).to have_selector('test-govuk-component[data-template="govuk_component-beta_label"]')
   end
 
   scenario "viewing a manual with a description" do

--- a/spec/unit/manual_presenter_spec.rb
+++ b/spec/unit/manual_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'gds_api/content_store'
+
+RSpec.describe ManualPresenter do
+  subject { described_class.new(manual) }
+  let(:content_store) { GdsApi::ContentStore.new(Plek.new.find('content-store')) }
+
+  context 'for a normal manual' do
+    let(:manual) do
+      stub_fake_manual
+      content_store.content_item "/guidance/my-manual-about-burritos"
+    end
+
+    it 'does not think it is an hmrc manual' do
+      expect(subject.hmrc?).to eq false
+    end
+
+    it 'does not think it is a beta manual' do
+      expect(subject.beta?).to eq false
+    end
+  end
+
+  context 'for an HMRC manual' do
+    let(:manual) do
+      stub_hmrc_manual
+      content_store.content_item "/hmrc-internal-manuals/inheritance-tax-manual"
+    end
+
+    it 'knows it is an hmrc manual' do
+      expect(subject.hmrc?).to eq true
+    end
+
+    it 'knows it is a beta manual' do
+      expect(subject.beta?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/J8ER0vhZ/64-remove-beta-label-from-manuals

The beta information is not in the content item so we just toggle on the HMRC-ness of the manual, which is enough for this story.