### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -47,7 +47,7 @@ rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 (
   cd tmp/govuk-content-schemas
-  git checkout ${SCHEMA_GIT_COMMIT:-"master"}
+  git checkout ${SCHEMA_GIT_COMMIT:-"deployed-to-production"}
 )
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Manuals Frontend app that don't
work with the currently deployed govuk-content-schemas (this changes
comes from GOV.UK RFC 59).