### PR TITLE
Give keyboard access to collapsible headings

### DIFF
--- a/app/assets/javascripts/collapsible.js
+++ b/app/assets/javascripts/collapsible.js
@@ -7,7 +7,15 @@
     this.$clickTarget = this.$section.find('.js-subsection-title');
     this.$clickTarget.on('click', this.toggle.bind(this));
     this.addToggle();
+
+    this.$section.on('focus', '.js-subsection-body a', this.showSectionWhenLinkFocused.bind(this));
   }
+
+  Collapsible.prototype.showSectionWhenLinkFocused = function() {
+    if (this.$section.is('.closed')) {
+      this.$section.toggleClass('closed');
+    }
+  };
 
   Collapsible.prototype.addToggle = function addToggle(){
     var $toggleHTML = $("<span class='js-toggle'></span>");

--- a/app/assets/javascripts/collapsible_collection.js
+++ b/app/assets/javascripts/collapsible_collection.js
@@ -31,7 +31,7 @@
 
       this.$container.on('click', 'a[rel="footnote"]', this.expandFootnotes.bind(this));
 
-      this.$container.on('click', 'a', function(event){
+      this.$container.on('click', '.body-content-wrapper a', function(event){
         if (window.location.pathname === event.target.pathname) {
           this.openCollapsibleForAnchor(event.currentTarget.hash);
         }
@@ -63,7 +63,10 @@
     // The DOM now contains poperly marked up sections to which collapsible functions can attach.
 
     var subsectionHeaders = this.$container.find(this.collapseSelector);
-    subsectionHeaders.addClass('js-subsection-title');
+    subsectionHeaders.each(function() {
+      var $header = $(this);
+      $header.addClass('js-subsection-title').wrapInner('<a role="button" href="#' + $header.attr('id') + '"></a>');
+    });
 
     subsectionHeaders.each(function(index, el){
       var $subsectionHeader = $(el),

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -272,14 +272,16 @@ main {
   }
 
   .collapsible-subsections .js-subsection-title {
-    @include core-19;
-    font-weight:bold;
+    @include bold-19;
+    display: block;
     border-top: 1px solid $border-colour;
     padding: $gutter-one-third $gutter $gutter-one-third 0;
     margin: $gutter 0;
-    text-decoration: none;
-    display: block;
     position: relative;
+
+    a {
+      text-decoration: none;
+    }
   }
 
   .subsection-collection {
@@ -336,10 +338,9 @@ main {
     .js-subsection-title {
       cursor: pointer;
       margin: 0;
-      color:$link-colour;
-      border:none;
+      border: none;
       @include ie-lte(7){
-        zoom:1;
+        zoom: 1;
       }
 
       .js-toggle {


### PR DESCRIPTION
Quick fix, doesn't fix all accessibility concerns with these toggles; eg ARIA states, odd tabbing behaviour on visually hidden links (patched but not fixed), etc.

The current heading toggles can’t be opened with a keyboard. By dynamically adding links inside the headings we get all the correct tabindex and focus behaviour.

https://www.gov.uk/guidance/content-design/what-is-content-design

* Use the ID of the heading as the href target
* Another JS listener listens for clicks on links. This has been reduced in scope to body links (for expanding/closing footnotes).
* Show section when focussing on hidden links

Because content is visually hidden, the links within the content blocks can still be tabbed too. Rather than tabbing to something you can’t see, which feels broken, if the section isn’t visible, automatically open the section. (Sometimes the browser doesn't scroll to the focused link, sometimes it does.)

![tabbing-manuals](https://cloud.githubusercontent.com/assets/319055/20976661/1b8a4eee-bc9b-11e6-892b-ddc1d2ddc8b6.gif)

@nickcolley @cfq @aduggin