### PR TITLE
Wrap siblings method in guard conditional

### DIFF
--- a/app/presenters/sibling_decorator.rb
+++ b/app/presenters/sibling_decorator.rb
@@ -21,9 +21,11 @@ private
   end
 
   def siblings
-    parent.details.child_section_groups.map(&:child_sections).find { |section|
-      section.map(&:section_id).include?(current_section_id)
-    }
+    if parent
+      parent.details.child_section_groups.map(&:child_sections).find { |section|
+        section.map(&:section_id).include?(current_section_id)
+      }
+    end
   end
 
   def adjacent_siblings

--- a/spec/unit/sibling_decorator_spec.rb
+++ b/spec/unit/sibling_decorator_spec.rb
@@ -268,4 +268,19 @@ describe SiblingDecorator do
     end
   end
 
+  context "for a section whose parent doesn't exist" do
+    let(:parent) { nil }
+
+    describe "#previous_sibling" do
+      it "should be nil" do
+        expect(decorator.previous_sibling).to be_nil
+      end
+    end
+
+    describe "#next_sibling" do
+      it "should be nil" do
+        expect(decorator.next_sibling).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
The content store contains some manuals child pages where the parent doesn't exist. This means that `parent` is nil so `parent.details` causes an error.

This change will allow the child page to render even when it doesn't have a parent.