### PR TITLE
Handle a manual's public_updated_at being null

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,14 +7,14 @@ module ApplicationHelper
   end
 
   def marked_up_date(date, format = :long)
-    content_tag(:time, localize(date, format: format), datetime: date.iso8601)
+    content_tag(:time, localize(date, format: format), datetime: date.iso8601) if date.present?
   end
 
   def previous_and_next_links(document)
     siblings = {}
 
     if document.previous_sibling
-      siblings.merge!( 
+      siblings.merge!(
         previous_page: {
           title: "Previous page",
           url: document.previous_sibling.base_path

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -19,7 +19,7 @@ class ManualPresenter
   end
 
   def updated_at
-    Date.parse(manual.public_updated_at)
+    Date.parse(manual.public_updated_at) if manual.public_updated_at.present?
   end
 
   def organisations

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -15,7 +15,8 @@ class RedirectPublisher
     redirect = {
       "content_id" => content_id,
       "base_path" => base_path,
-      "format" => "redirect",
+      "schema_name" => "redirect",
+      "document_type" => "redirect",
       "publishing_app" => publishing_app,
       "redirects" => [
         {

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -16,13 +16,13 @@ module ManualHelpers
     ).fetch("links")
   end
 
-  def stub_fake_manual
+  def stub_fake_manual(public_updated_at: "2014-06-20T10:17:29+01:00")
     manual_json = {
       base_path: "/guidance/my-manual-about-burritos",
       title: "My manual about Burritos",
       description: "Burrito means little donkey",
       format: "manual",
-      public_updated_at: "2014-06-20T10:17:29+01:00",
+      public_updated_at: public_updated_at,
       links: example_links,
       details: {
         child_section_groups: [

--- a/spec/unit/application_helper_spec.rb
+++ b/spec/unit/application_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'gds_api/content_store'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#marked_up_date' do
+    it 'returns nil when the supplied date is also nil' do
+      expect(helper.marked_up_date(nil)).to be_nil
+    end
+
+    it 'returns a time element when the supplied date is present' do
+      expect(helper.marked_up_date(Date.today)).to match(%r{^<time.*</time>})
+    end
+  end
+end

--- a/spec/unit/manual_presenter_spec.rb
+++ b/spec/unit/manual_presenter_spec.rb
@@ -34,4 +34,27 @@ RSpec.describe ManualPresenter do
       expect(subject.beta?).to eq true
     end
   end
+
+  context '#updated_at' do
+    let(:manual) do
+      stub_fake_manual(public_updated_at: public_updated_at)
+      content_store.content_item "/guidance/my-manual-about-burritos"
+    end
+
+    context 'when the public_updated_at of the content item is populated' do
+      let(:public_updated_at) { "2014-06-20T10:17:29+01:00" }
+
+      it "parses the public_updated_at to return a Date object" do
+        expect(subject.updated_at).to eq Date.new(2014,06,20)
+      end
+    end
+
+    context 'when the public_updated_at of the content item is missing' do
+      let(:public_updated_at) { nil }
+
+      it "returns nil" do
+        expect(subject.updated_at).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
We've recently changed manuals-publisher so that it no longer sends dates
to the publishing-api when writing drafts or publishing.  This means that
the publishing-api handles all the updated_at, first_published_at, and
public_updated_at values that appear in the content store.  One side-effect
of this is that drafts of a manual have a null value for the
public_updated_at in the content store.  Note that we expect this for the
first draft of a new manual, but we're seeing it for other drafts too.

To avoid breaking manuals-frontend in this situation we add some guard
clauses to the presenter and helpers.

For https://trello.com/c/OC3RskhE/63-timestamps-on-manuals and in response to changes in https://github.com/alphagov/manuals-publisher/pull/780