### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,46 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'manuals-frontend'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage('Bundle') {
+      govuk.bundleApp()
+    }
+
+    stage('Tests') {
+      govuk.runRakeTask("default")
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      stage('Push release tag') {
+        govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
+      }
+
+      stage('Deploy to Integration') {
+        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
+      }
+    }
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
For now `jenkins.sh` and `jenkins-schema.sh` survive, because they ensure that changes to the schema project will be tested against manuals-frontend. (see comment by suzannehamilton below)

This can be improved once [this pr](https://github.com/alphagov/govuk-puppet/pull/5306) has been merged, and puppet run on Jenkins.

[Trello](https://trello.com/c/Bsn36Agy/595-create-jenkinsfile-for-manuals-frontend)