### PR TITLE
Introduce border-bottom in beta label for A/B test

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,8 +27,10 @@ main {
 .manuals-frontend-body {
   padding-bottom: $gutter;
 
-  .govuk-beta-label {
-    border-bottom: none;
+  .manual-in-beta {
+    .govuk-beta-label {
+      border-bottom: none;
+    }
   }
 
   header {

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -6,7 +6,9 @@
   )
 %>
 <% if presented_manual.beta? %>
-  <%= render partial: 'govuk_component/beta_label' %>
+  <div class='manual-in-beta'>
+    <%= render partial: 'govuk_component/beta_label' %>
+  </div>
 <% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%= render 'manual_breadcrumbs', presented_manual: presented_manual %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -6,7 +6,9 @@
   )
 %>
 <% if presented_manual.beta? %>
-  <%= render partial: 'govuk_component/beta_label' %>
+  <div class='manual-in-beta'>
+    <%= render partial: 'govuk_component/beta_label' %>
+  </div>
 <% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%=

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -9,7 +9,9 @@
   <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
 <% end %>
 <% if presented_manual.beta? %>
-  <%= render partial: 'govuk_component/beta_label' %>
+  <div class='manual-in-beta'>
+    <%= render partial: 'govuk_component/beta_label' %>
+  </div>
 <% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%=


### PR DESCRIPTION
This application hides the border bottom of the beta label for design
purposes.  That's fine in the existing behaviour, but for the A/B test
the beta label has other elements underneath it (e.g. breadcrumbs). This
means we should show the border bottom in those cases.

Trello: https://trello.com/c/V6PSacVC/336-changes-to-education-related-content-pages-as-part-of-the-new-navigation-in-manuals-frontend

HMRC Manual stays the same:

<img width="1088" alt="screen shot 2017-02-23 at 10 16 48" src="https://cloud.githubusercontent.com/assets/416701/23254945/b3b118f8-f9b1-11e6-999b-f651c4a1a0e1.png">

But the new manual now has the expected border bottom:

<img width="1132" alt="screen shot 2017-02-23 at 10 16 32" src="https://cloud.githubusercontent.com/assets/416701/23254958/bbaf9606-f9b1-11e6-96aa-d2e4c296b511.png">
