### PR TITLE
Column two thirds in manuals ab test

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,14 +16,6 @@ main {
   display: block;
 }
 
-.outer-block {
-  @include outer-block;
-}
-
-.inner-block {
-  @include inner-block;
-}
-
 .manuals-frontend-body {
   padding-bottom: $gutter;
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 private
 
   def slimmer_headers
-    slimmer_template "header_footer_only"
+    slimmer_template 'core_layout'
     set_slimmer_headers(remove_search: true)
   end
 end

--- a/app/views/manuals/index.html+new_navigation.erb
+++ b/app/views/manuals/index.html+new_navigation.erb
@@ -11,5 +11,13 @@
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_manual.taxonomy_breadcrumbs %>
-<%= render 'header', presented_manual: presented_manual %>
-<%= render 'manual', presented_manual: presented_manual %>
+
+<div class='grid-row'>
+  <div class='column-two-thirds'>
+    <%= render 'header', presented_manual: presented_manual %>
+    <%= render 'manual', presented_manual: presented_manual %>
+  </div>
+  <div class='column-one-third'>
+    <%# Placeholder for new side navigation %>
+  </div>
+</div>

--- a/app/views/manuals/show.html+new_navigation.erb
+++ b/app/views/manuals/show.html+new_navigation.erb
@@ -11,11 +11,19 @@
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_document.taxonomy_breadcrumbs %>
-<%= render 'header', presented_manual: presented_manual %>
-<%=
-  render(
-    'manual_section',
-    presented_manual: presented_manual,
-    presented_document: presented_document
-  )
-%>
+
+<div class='grid-row'>
+  <div class='column-two-thirds'>
+    <%= render 'header', presented_manual: presented_manual %>
+    <%=
+      render(
+        'manual_section',
+        presented_manual: presented_manual,
+        presented_document: presented_document
+      )
+    %>
+  </div>
+  <div class='column-one-third'>
+    <%# Placeholder for new side navigation %>
+  </div>
+</div>

--- a/app/views/manuals/updates.html+new_navigation.erb
+++ b/app/views/manuals/updates.html+new_navigation.erb
@@ -11,5 +11,13 @@
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_manual.taxonomy_breadcrumbs %>
-<%= render 'header', presented_manual: presented_manual %>
-<%= render 'manual_updates', presented_manual: presented_manual %>
+
+<div class='grid-row'>
+  <div class='column-two-thirds'>
+    <%= render 'header', presented_manual: presented_manual %>
+    <%= render 'manual_updates', presented_manual: presented_manual %>
+  </div>
+  <div class='column-one-third'>
+    <%# Placeholder for new side navigation %>
+  </div>
+</div>


### PR DESCRIPTION
This PR moves the manual pages into a `column-two-thirds` layout in order to make space for side navigation.

Trello: https://trello.com/c/V6PSacVC/336-changes-to-education-related-content-pages-as-part-of-the-new-navigation-in-manuals-frontend

The manual page:

<img width="1091" alt="screen shot 2017-02-23 at 10 35 37" src="https://cloud.githubusercontent.com/assets/416701/23255681/70d1df06-f9b4-11e6-8986-c3e44ade91d1.png">

The manual section page:

<img width="1079" alt="screen shot 2017-02-23 at 10 35 47" src="https://cloud.githubusercontent.com/assets/416701/23255687/755f9c48-f9b4-11e6-8006-e001545df247.png">

The manual updates' page:

<img width="1091" alt="screen shot 2017-02-23 at 10 35 57" src="https://cloud.githubusercontent.com/assets/416701/23255695/7c591fce-f9b4-11e6-932c-168f2cf604cb.png">
