### PR TITLE
Use new `with_variant` from govuk_ab_testing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
 gem 'govuk_navigation_helpers', '2.3.1'
-gem 'govuk_ab_testing', '0.1.5'
+gem 'govuk_ab_testing', '0.2.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.1.5)
+    govuk_ab_testing (0.2.0)
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -268,7 +268,7 @@ DEPENDENCIES
   gds-api-adapters (= 26.7.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 0.1.5)
+  govuk_ab_testing (= 0.2.0)
   govuk_frontend_toolkit (= 1.2.0)
   govuk_navigation_helpers (= 2.3.1)
   jasmine-rails

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'climate_control'
 
 feature "Viewing manuals and sections" do
-  include GovukAbTesting::MinitestHelpers
+  include GovukAbTesting::RspecCapybaraHelpers
 
   around(:each) do |example|
     ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
@@ -13,7 +13,7 @@ feature "Viewing manuals and sections" do
   scenario "viewing a manual with the new navigation" do
     stub_education_manual
 
-    with_b_variant do
+    with_variant EducationNavigation: 'B' do
       visit_manual "buying-for-schools"
 
       expect_component('beta_label')
@@ -39,7 +39,7 @@ feature "Viewing manuals and sections" do
     stub_education_manual
     stub_education_manual_section
 
-    with_b_variant do
+    with_variant EducationNavigation: 'B' do
       visit_manual "buying-for-schools"
       select_section "1. Plan your procurement process"
 
@@ -68,7 +68,7 @@ feature "Viewing manuals and sections" do
   scenario "viewing change notes for a manual with the new navigation" do
     stub_education_manual
 
-    with_b_variant do
+    with_variant EducationNavigation: 'B' do
       visit_manual "buying-for-schools"
       view_manual_change_notes
 
@@ -89,23 +89,5 @@ feature "Viewing manuals and sections" do
         expect(breadcrumbs.last['is_current_page']).to be_truthy
       end
     end
-  end
-
-private
-
-  # TODO: port this behaviour to govuk_ab_testing
-  def with_b_variant
-    ab_test = GovukAbTesting::AbTest.new('EducationNavigation', dimension: nil)
-    page.driver.header(ab_test.response_header, 'B')
-
-    yield
-
-    expect(ab_test.response_header).to eq(page.response_headers['Vary'])
-
-    content = [ab_test.meta_tag_name, 'B'].join(':')
-    ab_test_metatag = page.find("meta[name='govuk:ab-test']", visible: false)
-
-    expect(ab_test_metatag['content']).to eq(content)
-    expect(ab_test_metatag['data-analytics-dimension']).to eq("41")
   end
 end


### PR DESCRIPTION
This commit takes advantage of the new test helpers created in
govuk_ab_testing that support RSpec and Capybara.

More details in: https://github.com/alphagov/govuk_ab_testing/pull/17

Trelo: https://trello.com/c/V6PSacVC/336-changes-to-education-related-content-pages-as-part-of-the-new-navigation-in-manuals-frontend