### PR TITLE
Fix AB testing meta tags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,16 @@ class ApplicationController < ActionController::Base
 
   before_filter :slimmer_headers
 
+  helper_method :ab_test
+
 private
 
   def slimmer_headers
     slimmer_template 'core_layout'
     set_slimmer_headers(remove_search: true)
+  end
+
+  def ab_test
+    @ab_test ||= EducationNavigationAbTestRequest.new(request)
   end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -38,10 +38,6 @@ class ManualsController < ApplicationController
 
 private
 
-  def ab_test
-    @ab_test ||= EducationNavigationAbTestRequest.new(request)
-  end
-
   def set_up_education_navigation_ab_testing
     ab_test.set_response_vary_header(response)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/manuals/index.html+new_navigation.erb
+++ b/app/views/manuals/index.html+new_navigation.erb
@@ -5,9 +5,6 @@
     title: presented_manual.full_title
   )
 %>
-<%= content_for :extra_head_content do %>
-  <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
-<% end %>
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_manual.taxonomy_breadcrumbs %>

--- a/app/views/manuals/show.html+new_navigation.erb
+++ b/app/views/manuals/show.html+new_navigation.erb
@@ -5,9 +5,6 @@
     title: presented_document.full_title
   )
 %>
-<%= content_for :extra_head_content do %>
-  <%= ab_test.analytics_meta_tag.html_safe %>
-<% end %>
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_document.taxonomy_breadcrumbs %>

--- a/app/views/manuals/updates.html+new_navigation.erb
+++ b/app/views/manuals/updates.html+new_navigation.erb
@@ -5,9 +5,6 @@
     title: 'Updates - ' + presented_manual.full_title
   )
 %>
-<%= content_for :extra_head_content do %>
-  <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
-<% end %>
 <%= render 'govuk_component/beta_label' %>
 <%= render 'govuk_component/breadcrumbs',
   breadcrumbs: presented_manual.taxonomy_breadcrumbs %>

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -10,6 +10,16 @@ feature "Viewing manuals and sections" do
     end
   end
 
+  scenario "viewing a manual with the old navigation" do
+    stub_education_manual
+
+    with_variant EducationNavigation: 'A' do
+      visit_manual "buying-for-schools"
+
+      expect_no_component('beta_label')
+    end
+  end
+
   scenario "viewing a manual with the new navigation" do
     stub_education_manual
 


### PR DESCRIPTION
Prior to this fix, the AB testing `meta` tag was only being applied to "B" variants of the rendered pages. This is incorrect, as it will fail to correctly track visits to "A" variants (and also manifests itself in not being able to switch A/B group in the Chrome plugin)

### Trello

https://trello.com/c/djVxzKfU/442-investigate-weird-behaviour-where-the-a-b-test-option-doesn-t-always-show-from-the-chrome-extension
