### PR TITLE
Upgrade govuk_ab_testing to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
 gem 'govuk_navigation_helpers', '2.3.1'
-gem 'govuk_ab_testing', '0.2.0'
+gem 'govuk_ab_testing', '1.0.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.2.0)
+    govuk_ab_testing (1.0.0)
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -268,7 +268,7 @@ DEPENDENCIES
   gds-api-adapters (= 26.7.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 0.2.0)
+  govuk_ab_testing (= 1.0.0)
   govuk_frontend_toolkit (= 1.2.0)
   govuk_navigation_helpers (= 2.3.1)
   jasmine-rails

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -9,7 +9,7 @@ class EducationNavigationAbTestRequest
       "EducationNavigation",
       dimension: dimension
     )
-    @requested_variant = ab_test.requested_variant(request)
+    @requested_variant = ab_test.requested_variant(request.headers)
   end
 
   def should_present_new_navigation_view?(content_item)

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'climate_control'
 
 feature "Viewing manuals and sections" do
-  include GovukAbTesting::RspecCapybaraHelpers
+  include GovukAbTesting::RspecHelpers
 
   around(:each) do |example|
     ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,3 +13,7 @@ require 'rspec/rails'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure(&:infer_spec_type_from_file_location!)
+
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :capybara
+end


### PR DESCRIPTION
Main changes are:
- passing in the request headers to the variant checker;
- setting the acceptance testing framework in the configuration of the
  gem.

Gem changes: https://github.com/alphagov/govuk_ab_testing/pull/20

Trello: https://trello.com/c/t4n8kPpx/434-make-sure-collections-can-be-toggled-with-the-a-b-test-and-react-to-it