### PR TITLE
Add taxonomy sidebar to new navigation pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'gds-api-adapters', '40.1.0'
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_navigation_helpers', '2.4.0'
+gem 'govuk_navigation_helpers', '~> 3.0'
 gem 'govuk_ab_testing', '1.0.0'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'gds-api-adapters', '40.1.0'
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_navigation_helpers', '2.3.1'
+gem 'govuk_navigation_helpers', '2.4.0'
 gem 'govuk_ab_testing', '1.0.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,8 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.4.0)
+    govuk_navigation_helpers (3.0.1)
+      gds-api-adapters (~> 40.1)
     hashdiff (0.3.0)
     hike (1.2.3)
     http-cookie (1.0.3)
@@ -269,7 +270,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.0)
   govuk_frontend_toolkit (= 1.2.0)
-  govuk_navigation_helpers (= 2.4.0)
+  govuk_navigation_helpers (~> 3.0)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.3.1)
+    govuk_navigation_helpers (2.4.0)
     hashdiff (0.3.0)
     hike (1.2.3)
     http-cookie (1.0.3)
@@ -269,7 +269,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.0)
   govuk_frontend_toolkit (= 1.2.0)
-  govuk_navigation_helpers (= 2.3.1)
+  govuk_navigation_helpers (= 2.4.0)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -34,7 +34,7 @@ class ManualPresenter < SimpleDelegator
   end
 
   def taxonomy_sidebar
-    @taxonomy_sidebar ||= nav_helper.taxonomy_sidebar[:sections]
+    @taxonomy_sidebar ||= nav_helper.taxonomy_sidebar[:items]
   end
 
   def nav_helper

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -33,6 +33,10 @@ class ManualPresenter < SimpleDelegator
     @taxonomy_breadcrumbs ||= nav_helper.taxon_breadcrumbs[:breadcrumbs]
   end
 
+  def taxonomy_sidebar
+    @taxonomy_sidebar ||= nav_helper.taxonomy_sidebar[:sections]
+  end
+
   def nav_helper
     @nav_helper ||=
       GovukNavigationHelpers::NavigationHelper.new(@manual.content_store_manual.to_h)

--- a/app/views/manuals/_taxonomy_sidebar.html.erb
+++ b/app/views/manuals/_taxonomy_sidebar.html.erb
@@ -1,0 +1,1 @@
+<%= render 'govuk_component/taxonomy_sidebar', sections: presented_manual.taxonomy_sidebar %>

--- a/app/views/manuals/_taxonomy_sidebar.html.erb
+++ b/app/views/manuals/_taxonomy_sidebar.html.erb
@@ -1,1 +1,1 @@
-<%= render 'govuk_component/taxonomy_sidebar', sections: presented_manual.taxonomy_sidebar %>
+<%= render 'govuk_component/taxonomy_sidebar', items: presented_manual.taxonomy_sidebar %>

--- a/app/views/manuals/index.html+new_navigation.erb
+++ b/app/views/manuals/index.html+new_navigation.erb
@@ -15,6 +15,6 @@
     <%= render('manual', presented_manual: presented_manual) %>
   </div>
   <div class='column-one-third'>
-    <%# Placeholder for new side navigation %>
+    <%= render 'taxonomy_sidebar', presented_manual: presented_manual %>
   </div>
 </div>

--- a/app/views/manuals/show.html+new_navigation.erb
+++ b/app/views/manuals/show.html+new_navigation.erb
@@ -21,6 +21,6 @@
     %>
   </div>
   <div class='column-one-third'>
-    <%# Placeholder for new side navigation %>
+    <%= render 'taxonomy_sidebar', presented_manual: presented_manual %>
   </div>
 </div>

--- a/app/views/manuals/updates.html+new_navigation.erb
+++ b/app/views/manuals/updates.html+new_navigation.erb
@@ -15,6 +15,6 @@
     <%= render 'manual_updates', presented_manual: presented_manual %>
   </div>
   <div class='column-one-third'>
-    <%# Placeholder for new side navigation %>
+    <%= render 'taxonomy_sidebar', presented_manual: presented_manual %>
   </div>
 </div>

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -109,16 +109,13 @@ feature "Viewing manuals and sections" do
 
   def expect_taxonomy_sidebar
     expect_component('taxonomy_sidebar') do |sidebar_data|
-      sidebar = sidebar_data['sections']
+      sidebar = sidebar_data['items']
+
       expect(sidebar).to include(
-        "title" => "More about",
-        "items" => [
-          {
-            "title" => "Education, training and skills",
-            "url" => "/education",
-            "description" => "Education, training and skills I guess",
-          }
-        ]
+        "title" => "Education, training and skills",
+        "url" => "/education",
+        "description" => "Education, training and skills I guess",
+        "related_content" => []
       )
     end
   end

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -42,6 +42,8 @@ feature "Viewing manuals and sections" do
         )
         expect(breadcrumbs.last['is_current_page']).to be_truthy
       end
+
+      expect_taxonomy_sidebar
     end
   end
 
@@ -72,6 +74,8 @@ feature "Viewing manuals and sections" do
         )
         expect(breadcrumbs.last['is_current_page']).to be_truthy
       end
+
+      expect_taxonomy_sidebar
     end
   end
 
@@ -98,6 +102,24 @@ feature "Viewing manuals and sections" do
         )
         expect(breadcrumbs.last['is_current_page']).to be_truthy
       end
+
+      expect_taxonomy_sidebar
+    end
+  end
+
+  def expect_taxonomy_sidebar
+    expect_component('taxonomy_sidebar') do |sidebar_data|
+      sidebar = sidebar_data['sections']
+      expect(sidebar).to include(
+        "title" => "More about",
+        "items" => [
+          {
+            "title" => "Education, training and skills",
+            "url" => "/education",
+            "description" => "Education, training and skills I guess",
+          }
+        ]
+      )
     end
   end
 end

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -27,7 +27,8 @@ module ManualHelpers
       links: {
         taxons: [{
           title: 'Education, training and skills',
-          base_path: '/education'
+          base_path: '/education',
+          description: 'Education, training and skills I guess',
         }]
       },
       details: {


### PR DESCRIPTION
Add the taxonomy sidebar component from static and rework the tests to
assert for the presence of the sidebar where appropriate.


![screen shot 2017-03-02 at 17 42 10](https://cloud.githubusercontent.com/assets/519250/23519655/9e0971e4-ff6f-11e6-96d0-bb9c1b24723e.png)
