### PR TITLE
Hide "Give feedback" link on Education A/B test

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,17 +27,13 @@ main {
 
   .new-navigation {
     header {
+      .secondary {
+        display: none;
+      }
+
       @include media(tablet) {
         .primary {
           width: 100%;
-        }
-
-        .secondary {
-          width: 100%;
-
-          .secondary-inner {
-            padding-left: 0;
-          }
         }
       }
     }


### PR DESCRIPTION
This commit hides the "Give feedback" link from the manual's header,
because there will be a link to provide feedback always on that page at
the top.

### Before

<img width="1078" alt="screen shot 2017-03-02 at 11 56 28" src="https://cloud.githubusercontent.com/assets/416701/23506272/5b78d66a-ff3f-11e6-82ee-2d237b00b6e2.png">

### After

#### Desktop

<img width="1064" alt="screen shot 2017-03-02 at 11 55 26" src="https://cloud.githubusercontent.com/assets/416701/23506281/65c153d6-ff3f-11e6-9dcb-138db544a457.png">

#### Mobile

<img width="399" alt="screen shot 2017-03-02 at 11 55 34" src="https://cloud.githubusercontent.com/assets/416701/23506293/724e8ee8-ff3f-11e6-9d9c-2ca254c85707.png">

### Outside the B variant (left as normal)

<img width="1101" alt="screen shot 2017-03-02 at 11 55 51" src="https://cloud.githubusercontent.com/assets/416701/23506308/848c5f7c-ff3f-11e6-87e5-aab7f5da9d4f.png">


Trello: https://trello.com/c/jHv8IAwx/470-remove-give-feedback-about-this-page-link-from-b-variant-of-manuals-frontend