### PR TITLE
Upgrade govuk_navigation_helpers to 3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.0.1)
+    govuk_navigation_helpers (3.0.2)
       gds-api-adapters (~> 40.1)
     hashdiff (0.3.0)
     hike (1.2.3)


### PR DESCRIPTION
This makes sure parent taxons in the breadrumbs are selected from a list
of ordered parent taxons.

Trello: https://trello.com/c/RLWfiG6N/481-make-breadcrumb-use-1st-alphabetic-topic