### PR TITLE
Remove the New Navigation feature flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,5 +35,4 @@ group :test do
   gem "poltergeist", "1.5.0"
   gem "launchy"
   gem "govuk-content-schema-test-helpers", "1.3.0"
-  gem 'climate_control', '~> 0.1.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.0)
     crack (0.4.3)
@@ -264,7 +263,6 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   better_errors
   binding_of_caller
-  climate_control (~> 0.1.0)
   gds-api-adapters (= 40.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -15,7 +15,6 @@ class EducationNavigationAbTestRequest
   def should_present_new_navigation_view?(content_item)
     [
       requested_variant.variant_b?,
-      new_navigation_enabled?,
       content_is_tagged_to_a_taxon?(content_item)
     ].all?
   end
@@ -25,10 +24,6 @@ class EducationNavigationAbTestRequest
   end
 
 private
-
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
 
   def content_is_tagged_to_a_taxon?(content_item)
     content_item.dig("links", "taxons").present?

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -1,14 +1,7 @@
 require 'rails_helper'
-require 'climate_control'
 
 feature "Viewing manuals and sections" do
   include GovukAbTesting::RspecHelpers
-
-  around(:each) do |example|
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
-      example.run
-    end
-  end
 
   scenario "viewing a manual with the old navigation" do
     stub_education_manual


### PR DESCRIPTION
This means we can toggle the A/B variant in production via the chrome
extension. When we rollout the new navigation with a Fastly
configuration change, the % of users we select will start seeing these
new pages.

Trello: https://trello.com/c/940kowVa/484-remove-enable-new-navigation-check-from-repos-and-from-puppet