### PR TITLE
Only add A/B testing Vary header and meta tag to education pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
 gem 'govuk_navigation_helpers', '~> 3.0'
-gem 'govuk_ab_testing', '1.0.0'
+gem 'govuk_ab_testing', '1.0.4'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (1.0.0)
+    govuk_ab_testing (1.0.4)
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -266,7 +266,7 @@ DEPENDENCIES
   gds-api-adapters (= 40.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 1.0.0)
+  govuk_ab_testing (= 1.0.4)
   govuk_frontend_toolkit (= 1.2.0)
   govuk_navigation_helpers (~> 3.0)
   jasmine-rails

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -39,7 +39,9 @@ class ManualsController < ApplicationController
 private
 
   def set_up_education_navigation_ab_testing
-    ab_test.set_response_vary_header(response)
+    if ab_test.page_is_under_ab_test?(content_store_manual)
+      ab_test.set_response_vary_header(response)
+    end
 
     if ab_test.should_present_new_navigation_view?(content_store_manual)
       request.variant = :new_navigation

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -15,8 +15,12 @@ class EducationNavigationAbTestRequest
   def should_present_new_navigation_view?(content_item)
     [
       requested_variant.variant_b?,
-      content_is_tagged_to_a_taxon?(content_item)
+      page_is_under_ab_test?(content_item)
     ].all?
+  end
+
+  def page_is_under_ab_test?(content_item)
+    content_is_tagged_to_a_taxon?(content_item)
   end
 
   def set_response_vary_header(response)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
   <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
-  <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
   <%= yield :extra_head_content %>
 </head>
 <body>

--- a/app/views/manuals/_content_for_head_tag.html.erb
+++ b/app/views/manuals/_content_for_head_tag.html.erb
@@ -2,6 +2,7 @@
   <% if description.present? %>
     <meta name='description' content='<%= description %>' />
   <% end %>
+  <%= ab_test.requested_variant.analytics_meta_tag.html_safe if add_ab_meta_tag %>
 <% end %>
 
 <% content_for :title, title %>

--- a/app/views/manuals/index.html+new_navigation.erb
+++ b/app/views/manuals/index.html+new_navigation.erb
@@ -2,7 +2,8 @@
   render(
     'content_for_head_tag',
     description: presented_manual.summary,
-    title: presented_manual.full_title
+    title: presented_manual.full_title,
+    add_ab_meta_tag: true
   )
 %>
 <%= render 'govuk_component/beta_label' %>

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -2,7 +2,8 @@
   render(
     'content_for_head_tag',
     description: presented_manual.summary,
-    title: presented_manual.full_title
+    title: presented_manual.full_title,
+    add_ab_meta_tag: ab_test.page_is_under_ab_test?(presented_manual.content_store_manual)
   )
 %>
 <% if presented_manual.beta? %>

--- a/app/views/manuals/show.html+new_navigation.erb
+++ b/app/views/manuals/show.html+new_navigation.erb
@@ -2,7 +2,8 @@
   render(
     'content_for_head_tag',
     description: presented_manual.summary,
-    title: presented_document.full_title
+    title: presented_document.full_title,
+    add_ab_meta_tag: true
   )
 %>
 <%= render 'govuk_component/beta_label' %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -2,7 +2,8 @@
   render(
     'content_for_head_tag',
     description: presented_manual.summary,
-    title: presented_document.full_title
+    title: presented_document.full_title,
+    add_ab_meta_tag: ab_test.page_is_under_ab_test?(presented_manual.content_store_manual)
   )
 %>
 <% if presented_manual.beta? %>

--- a/app/views/manuals/updates.html+new_navigation.erb
+++ b/app/views/manuals/updates.html+new_navigation.erb
@@ -2,7 +2,8 @@
   render(
     'content_for_head_tag',
     description: "List of updates to '#{presented_manual.full_title}'.",
-    title: 'Updates - ' + presented_manual.full_title
+    title: 'Updates - ' + presented_manual.full_title,
+    add_ab_meta_tag: true
   )
 %>
 <%= render 'govuk_component/beta_label' %>

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -2,12 +2,10 @@
   render(
     'content_for_head_tag',
     description: "List of updates to '#{presented_manual.full_title}'.",
-    title: 'Updates - ' + presented_manual.full_title
+    title: 'Updates - ' + presented_manual.full_title,
+    add_ab_meta_tag: ab_test.page_is_under_ab_test?(presented_manual.content_store_manual)
   )
 %>
-<%= content_for :extra_head_content do %>
-  <%= ab_test.requested_variant.analytics_meta_tag.html_safe %>
-<% end %>
 <% if presented_manual.beta? %>
   <div class='manual-in-beta'>
     <%= render partial: 'govuk_component/beta_label' %>

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -13,6 +13,18 @@ feature "Viewing manuals and sections" do
     end
   end
 
+  %w(A B).each do |variant|
+    scenario "viewing a manual outside the A/B test with variant #{variant}" do
+      stub_fake_manual
+
+      setup_ab_variant("EducationNavigation", variant)
+
+      visit_manual "my-manual-about-burritos"
+
+      assert_response_not_modified_for_ab_test
+    end
+  end
+
   scenario "viewing a manual with the new navigation" do
     stub_education_manual
 


### PR DESCRIPTION
Ensure that only pages in the navigation A/B test (those which are tagged to taxons) are cached separately and tracked in the A/B test analytics.

https://trello.com/c/Xehe42eM/464-only-add-a-b-meta-tag-to-pages-in-the-navigation-a-b-test