### PR TITLE
Update navigation helpers gem to pick up the latest taxonomy sidebar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.1.0)
+    govuk_navigation_helpers (3.1.1)
       gds-api-adapters (~> 40.1)
     hashdiff (0.3.0)
     hike (1.2.3)


### PR DESCRIPTION
The list of document types which appear in the sidebar has changed. This gem upgrade picks up the latest version.

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list