### PR TITLE
Convert taxon breadcrumbs to back link on mobile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.0)
+    govuk_navigation_helpers (3.2.1)
       gds-api-adapters (~> 40.1)
     hashdiff (0.3.0)
     hike (1.2.3)

--- a/app/views/manuals/index.html+new_navigation.erb
+++ b/app/views/manuals/index.html+new_navigation.erb
@@ -10,7 +10,8 @@
 <%= render 'taxonomy_beta_label' %>
 
 <%= render 'govuk_component/breadcrumbs',
-  breadcrumbs: presented_manual.taxonomy_breadcrumbs %>
+  breadcrumbs: presented_manual.taxonomy_breadcrumbs,
+  collapse_on_mobile: true %>
 
 <div class='grid-row new-navigation'>
   <div class='column-two-thirds'>

--- a/app/views/manuals/show.html+new_navigation.erb
+++ b/app/views/manuals/show.html+new_navigation.erb
@@ -10,7 +10,8 @@
 <%= render 'taxonomy_beta_label' %>
 
 <%= render 'govuk_component/breadcrumbs',
-  breadcrumbs: presented_document.taxonomy_breadcrumbs %>
+  breadcrumbs: presented_document.taxonomy_breadcrumbs,
+  collapse_on_mobile: true %>
 
 <div class='grid-row new-navigation'>
   <div class='column-two-thirds'>

--- a/app/views/manuals/updates.html+new_navigation.erb
+++ b/app/views/manuals/updates.html+new_navigation.erb
@@ -10,7 +10,8 @@
 <%= render 'taxonomy_beta_label' %>
 
 <%= render 'govuk_component/breadcrumbs',
-  breadcrumbs: presented_manual.taxonomy_breadcrumbs %>
+  breadcrumbs: presented_manual.taxonomy_breadcrumbs,
+  collapse_on_mobile: true %>
 
 <div class='grid-row'>
   <div class='column-two-thirds new-navigation'>

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -37,11 +37,11 @@ feature "Viewing manuals and sections" do
         breadcrumbs = breadcrumb_data['breadcrumbs']
 
         expect(breadcrumbs.count).to eq(3)
-        expect(breadcrumbs).to include("title" => "Home", "url" => "/")
-        expect(breadcrumbs).to include(
+        expect(breadcrumbs).to include(a_hash_including("title" => "Home", "url" => "/"))
+        expect(breadcrumbs).to include(a_hash_including(
           "title" => "Education, training and skills",
           "url" => "/education"
-        )
+        ))
         expect(breadcrumbs.last['title']).to match(
           /buying for schools/i
         )
@@ -65,15 +65,15 @@ feature "Viewing manuals and sections" do
       expect_component('breadcrumbs') do |breadcrumb_data|
         breadcrumbs = breadcrumb_data['breadcrumbs']
         expect(breadcrumbs.count).to eq(4)
-        expect(breadcrumbs).to include("title" => "Home", "url" => "/")
-        expect(breadcrumbs).to include(
+        expect(breadcrumbs).to include(a_hash_including("title" => "Home", "url" => "/"))
+        expect(breadcrumbs).to include(a_hash_including(
           "title" => "Education, training and skills",
           "url" => "/education"
-        )
-        expect(breadcrumbs).to include(
+        ))
+        expect(breadcrumbs).to include(a_hash_including(
           "title" => "Buying for schools",
           "url" => "/guidance/buying-for-schools"
-        )
+        ))
         expect(breadcrumbs.last['title']).to match(
           /1\. plan your procurement process/i
         )
@@ -97,11 +97,11 @@ feature "Viewing manuals and sections" do
         breadcrumbs = breadcrumb_data['breadcrumbs']
 
         expect(breadcrumbs.count).to eq(3)
-        expect(breadcrumbs).to include("title" => "Home", "url" => "/")
-        expect(breadcrumbs).to include(
+        expect(breadcrumbs).to include(a_hash_including("title" => "Home", "url" => "/"))
+        expect(breadcrumbs).to include(a_hash_including(
           "title" => "Education, training and skills",
           "url" => "/education"
-        )
+        ))
         expect(breadcrumbs.last['title']).to match(
           /buying for schools/i
         )


### PR DESCRIPTION
Upgrade the govuk_navigation_helpers gem to pick up the latest breadcrumb config. This adds the taxon back link on mobile.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link