### PR TITLE
Update govuk_navigation_helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'gds-api-adapters', '40.1.0'
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_navigation_helpers', '~> 3.2'
+gem 'govuk_navigation_helpers', '~> 4.0'
 gem 'govuk_ab_testing', '1.0.4'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.1)
+    govuk_navigation_helpers (4.0.0)
       gds-api-adapters (~> 40.1)
     hashdiff (0.3.0)
     hike (1.2.3)
@@ -269,7 +269,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.4)
   govuk_frontend_toolkit (= 1.2.0)
-  govuk_navigation_helpers (~> 3.2)
+  govuk_navigation_helpers (~> 4.0)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)


### PR DESCRIPTION
This picks up the latest version of the taxonomy sidebar. There should not be any user-visible changes - the library has just switched from a hard-coded list of guidance content to filtering it in search.

https://trello.com/c/PtQXkimK/520-switch-from-using-hardcoded-guidance-document-types-into-using-document-supertypes