### PR TITLE
Mouse tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
 gem 'govuk_navigation_helpers', '~> 4.0'
-gem 'govuk_ab_testing', '1.0.4'
+gem 'govuk_ab_testing', '~> 2.1'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (1.0.4)
+    govuk_ab_testing (2.1.0)
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -267,7 +267,7 @@ DEPENDENCIES
   gds-api-adapters (= 40.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 1.0.4)
+  govuk_ab_testing (~> 2.1)
   govuk_frontend_toolkit (= 1.2.0)
   govuk_navigation_helpers (~> 4.0)
   jasmine-rails

--- a/app/assets/javascripts/mouseflow.js
+++ b/app/assets/javascripts/mouseflow.js
@@ -1,0 +1,9 @@
+var _mfq = _mfq || [];
+
+(function() {
+  var mf = document.createElement("script");
+  mf.type = "text/javascript";
+  mf.async = true;
+  mf.src = "//cdn.mouseflow.com/projects/807ab5b2-3fe4-4b3b-b4d7-e83b8f6e71fe.js";
+  document.getElementsByTagName("head")[0].appendChild(mf);
+})();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,20 @@ class ApplicationController < ActionController::Base
   before_filter :slimmer_headers
 
   helper_method :ab_test
+  helper_method :benchmarking_ab_test
+  helper_method :should_track_mouse_movements?
+
+  def benchmarking_ab_test
+    @benchmarking_ab_test ||= begin
+      benchmarking_test = BenchmarkingAbTestRequest.new(request)
+      benchmarking_test.set_response_vary_header(response)
+      benchmarking_test
+    end
+  end
+
+  def should_track_mouse_movements?
+    benchmarking_ab_test.in_benchmarking?
+  end
 
 private
 

--- a/app/models/benchmarking_ab_test_request.rb
+++ b/app/models/benchmarking_ab_test_request.rb
@@ -1,0 +1,22 @@
+class BenchmarkingAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    dimension = Rails.application.config.benchmarking_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new(
+      "Benchmarking",
+      dimension: dimension
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+  end
+
+  def in_benchmarking?
+    requested_variant.variant_b?
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
   <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
+  <%= benchmarking_ab_test.requested_variant.analytics_meta_tag.html_safe %>
   <%= csrf_meta_tags %>
   <%= yield :extra_head_content %>
 </head>
@@ -23,5 +24,8 @@
       </div>
     </main>
   </div>
+  <% if should_track_mouse_movements? %>
+    <%= javascript_include_tag 'mouseflow' %>
+  <% end %>
 </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,11 @@ module ManualsFrontend
 
     config.assets.prefix = '/manuals-frontend'
 
+    # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+    config.assets.precompile += %w(
+      mouseflow.js
+    )
+
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'ALLOWALL'
@@ -38,5 +43,8 @@ module ManualsFrontend
     # Google Analytics dimension assigned to the education navigation A/B
     # test
     config.navigation_ab_test_dimension = 41
+
+    # Google Analytics dimension assigned to the benchmarking A/B test
+    config.benchmarking_ab_test_dimension = 49
   end
 end

--- a/spec/features/ab_testing_manuals_spec.rb
+++ b/spec/features/ab_testing_manuals_spec.rb
@@ -21,7 +21,7 @@ feature "Viewing manuals and sections" do
 
       visit_manual "my-manual-about-burritos"
 
-      assert_response_not_modified_for_ab_test
+      assert_response_not_modified_for_ab_test('EducationNavigation')
     end
   end
 

--- a/spec/features/benchmarking_spec.rb
+++ b/spec/features/benchmarking_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature "Benchmarking" do
+  include GovukAbTesting::RspecHelpers
+
+  scenario "shows the mouseflow tag when in the benchmarking test" do
+    stub_education_manual
+
+    with_variant Benchmarking: "B" do
+      visit_manual "buying-for-schools"
+
+      expect(page).to have_css("script[src*=mouseflow]", count: 1, visible: :all), "Expected to find one script tag with the mouseflow js code on the page"
+    end
+  end
+
+  scenario "does not show the mouseflow tag when not in the benchmarking test" do
+    stub_education_manual
+
+    with_variant Benchmarking: "A" do
+      visit_manual "buying-for-schools"
+
+      expect(page).to_not have_css("script[src*=mouseflow]", visible: :all), "Did not expect to find a script tag with the mouseflow js code on the page"
+    end
+  end
+end


### PR DESCRIPTION
### Background

We are going to conduct a 2nd round of Benchmarking in GOV.UK. The idea is that we will try it with the new Education Navigation enabled across GOV.UK and see how it performs against the current navigation patterns (mainstream browse pages, topics, etc).

Besides checking if people actually complete the tasks, we would also like to know more details about how they use the new navigation pages and also about the new orientation in content pages. In order to do that, we will track mouse movements and gather the results in a heatmap. We are using a software called mouseflow to do this.

The tracking code will only be present for the people doing the benchmarking test (around 60 people). It will be behind a new A/B test so the tracking doesn't run for other GOV.UK users. These 60 users will be presented with a consent form where this will be explained.

### What this PR does

This PR adds the Mouseflow tracking code behind a new A/B test (`GOVUK-ABTest-Benchmarking`). With this new A/B test, we will be able to enable Mouseflow for all 60 users in the benchmarking round. This will allow us to collect data on how the navigation pages are used and generate a heatmap in the end in order to help us understand what areas of the site will be improved.

Trello: https://trello.com/c/NJ6O76BR/281-heatmap-tracking