### PR TITLE
Display assets correctly on development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,4 +23,7 @@ ManualsFrontend::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = true
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 end


### PR DESCRIPTION
This commit adds a development-specific configuration to ensure the frontend uses the assets subdomain for all assets rather than “www”.

Before:

![screen shot 2017-04-04 at 12 16 47](https://cloud.githubusercontent.com/assets/444232/24654255/ce81ffe6-1930-11e7-8432-8842b5d28adc.png)

After:

![screen shot 2017-04-04 at 12 16 03](https://cloud.githubusercontent.com/assets/444232/24654260/d41020c8-1930-11e7-969a-c9de5fc01043.png)
