### PR TITLE
Bump slimmer from 9.0.1 to 10.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.7.1'
-gem 'slimmer', '9.0.1'
+gem 'slimmer', '~> 10.1.3'
 
 gem 'govuk_frontend_toolkit', '1.2.0'
 gem 'sass-rails', '~> 5.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,13 +214,13 @@ GEM
     scss_lint (0.52.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
-    slimmer (9.0.1)
+    slimmer (10.1.3)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (2.11.0)
@@ -279,7 +279,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0.6)
-  slimmer (= 9.0.1)
+  slimmer (~> 10.1.3)
   statsd-ruby (= 1.3.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   before_filter :slimmer_headers
 

--- a/spec/contracts/govuk_content_schemas_spec.rb
+++ b/spec/contracts/govuk_content_schemas_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/content_store'
-require 'slimmer/test_helpers/shared_templates'
-include Slimmer::TestHelpers::SharedTemplates
 
 feature "Viewing manuals and sections examples from govuk-content-schemas" do
   include GdsApi::TestHelpers::ContentStore

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'slimmer/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -1,8 +1,4 @@
-require 'slimmer/test_helpers/shared_templates'
-
 module AppHelpers
-  include Slimmer::TestHelpers::SharedTemplates
-
   def view_manual_change_notes
     updates_path = "#{current_path}/updates"
     expect_component("metadata", in_scope: 'header') do |metadata|

--- a/spec/support/slimmer.rb
+++ b/spec/support/slimmer.rb
@@ -1,1 +1,0 @@
-require 'slimmer/test'


### PR DESCRIPTION
We're seeing high memory usage for manuals-frontend that corresponds with component memory leaks.

* Fix memory leak with components: https://github.com/alphagov/slimmer/pull/191
* Stub locale requests: https://github.com/alphagov/slimmer/pull/159

cc @h-lame @tijmenb @cbaines 

# 10.1.3

* Fix memory leak in components

# 10.1.2

* Bugfix for request URI's encoded as ASCII

# 10.1.1

* Bugfix for caching behaviour

# 10.1.0

* Use `Rails.cache` as the cache for templates, locales and components. You can
  remove `config.slimmer.use_cache` for your application, as you can no longer
  opt-out of caching.
* Add a `User-Agent` header to all outgoing API requests

# 10.0.0

* Removes the need_id meta tag, which is no longer used.
* Removes the functionality for breadcrumbs, related links and artefact-powered
  metatags.
* Drop support for old Rails & Ruby versions. This gem now supports Rails 4.2 and 5.X
  on Ruby 2.1 and 2.2.
* Renames `Slimmer::SharedTemplates` to `Slimmer::GovukComponents`

# 9.6.0

* Adds an 'inside header inserter' processor which allows an application to
  inject a block of HTML after the logo by including a .inside-header element
  in their application’s output.
  (PR #167 https://github.com/alphagov/slimmer/pull/167)

* Remove `MetaViewportRemover` processor as it is no longer used.
  (PR #166 https://github.com/alphagov/slimmer/pull/166)

# 9.5.0

* Adds a Cucumber helper that makes it easy for host applications to
  configure Slimmer correctly under test.

  (PR #162 https://github.com/alphagov/slimmer/pull/162)

# 9.4.0

* Adds an RSpec helper that makes it easy for host applications to
  configure Slimmer correctly under test.

  Fixes `stub_shared_component_locales` helper to correctly stub HTTP
  requests to fetch locale information when rendering its templates.

  (PR #159 https://github.com/alphagov/slimmer/pull/159)

# 9.3.2

* Bugfix: Over time, the I18n backend would be chained in each request,
  causing the stack to grow too large and use too much memory

  (PR #157 https://github.com/alphagov/slimmer/pull/157)

# 9.3.1

* Allows frontend apps to stub component locales for example

  ```ruby
  class ActiveSupport::TestCase
    include Slimmer::TestHelpers::SharedTemplates

    def setup
      stub_shared_component_locales
    end
  end
  ```

  (PR #155 https://github.com/alphagov/slimmer/pull/155)

# 9.3.0

* Integrates translations from GOVUK Components to be used in applications

  When including `Slimmer::SharedComponents`, the I18nBackend will be chained to `Slimmer::I18nBackend` allowing translations in `static` to work in the frontend applications

  (PR #152 https://github.com/alphagov/slimmer/pull/152)

# 9.2.1

* Replaces deprecated `before_filter` calls in shared templates.

# 9.2.0

* Raise a custom `CouldNotRetrieveTemplate` exception when a connection to the assets server can't be made because of an SSL problem (PR #143).

# 9.1.0

* Allow applications to request components using full or partial component
  paths, eg "name", "name.raw" and "name.raw.html.erb". This allows
  components to be nested within other components.