### PR TITLE
Manual print page numbering

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -64,3 +64,17 @@ a {
     font-weight: bold;
   }
 }
+
+// TODO:
+// legislative lists are being published with hardcoded item numbers
+// when printing this results in doubled up numbering.
+// These styles hide browser numbering on these lists.
+// Ideally this would be a global solution not just in manuals-frontend
+.govuk-govspeak .legislative-list {
+  padding-left: 0;
+
+  &,
+  ol {
+    list-style: none;
+  }
+}


### PR DESCRIPTION
### Motivation
When printing `manual_sections` the browser generated list numbering on `legislative-lists` is doubling up with numbering / lettering put in the markup by publishers. This results in confusing list numbering in the print version.

Trello: https://trello.com/c/UibrijCb/6-2-immigration-manual-print-page-numbering

Example: https://www.gov.uk/guidance/immigration-rules/immigration-rules-appendix-fm-se-family-members-specified-evidence

### Description
This PR adds a `manuals-frontend` specific print style to hide the browser generated list numbers so that the publishers original numbering alone is visible in the print version.

### Before
<img width="983" alt="before-list" src="https://cloud.githubusercontent.com/assets/6338228/24764817/7be4c6f6-1aed-11e7-98e8-c2a4d8679135.png">

### After
<img width="988" alt="after-list" src="https://cloud.githubusercontent.com/assets/6338228/24764825/829356de-1aed-11e7-9c76-8262f3874872.png">