### PR TITLE
Upgrade to govuk_navigation_helpers 6.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8.2'
 
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '~> 41.0'
+gem 'gds-api-adapters', '~> 42.0.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_navigation_helpers', '~> 5.1'
+gem 'govuk_navigation_helpers', '6.0.1'
 gem 'govuk_ab_testing', '~> 2.1'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,11 +62,11 @@ GEM
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (41.0.0)
+    gds-api-adapters (42.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -84,8 +84,8 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (5.1.0)
-      gds-api-adapters (~> 41.0)
+    govuk_navigation_helpers (6.0.1)
+      gds-api-adapters (~> 42.0)
     hashdiff (0.3.0)
     hike (1.2.3)
     http-cookie (1.0.3)
@@ -175,7 +175,7 @@ GEM
     raindrops (0.13.0)
     rake (12.0.0)
     request_store (1.3.1)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -243,7 +243,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.3)
     unicorn (4.8.2)
       kgio (~> 2.6)
@@ -264,12 +264,12 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   better_errors
   binding_of_caller
-  gds-api-adapters (~> 41.0)
+  gds-api-adapters (~> 42.0.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
   govuk_ab_testing (~> 2.1)
   govuk_frontend_toolkit (= 1.2.0)
-  govuk_navigation_helpers (~> 5.1)
+  govuk_navigation_helpers (= 6.0.1)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)


### PR DESCRIPTION
This fixes the issue with repeated related links across different
taxons.

Trello: https://trello.com/c/I4rs80n1/80-remove-duplicated-related-links-across-all-parent-taxons