### PR TITLE
Manual search box visual fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -132,12 +132,16 @@ main {
         width: calc(100% - 47px);
         // scss-lint:enable DuplicateProperty
         border: none;
-        padding: 6px;
+        padding: 7px;
+
+        @include media(mobile){
+          padding: 9px 7px;
+        }
       }
 
       button {
-        width: 33px;
-        height: 33px;
+        width: 34px;
+        height: 34px;
         border: 1px solid $manual-search-button-colour;
         border-width: 0 0 0 1px;
         border-left-color: $manual-search-button-border-colour;
@@ -151,7 +155,7 @@ main {
         @include border-radius(0);
         @include device-pixel-ratio() {
           background-size: 52.5px 35px;
-          background-position: 115% 50%;
+          background-position: 100% 50%;
         }
       }
     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -133,9 +133,17 @@ main {
         // scss-lint:enable DuplicateProperty
         border: none;
         padding: 7px;
+        height: 20px;
 
-        @include media(mobile){
+        &.focus,
+        &:focus {
+          position: relative;
+          z-index: 1;
+        }
+
+        @include media(mobile) {
           padding: 9px 7px;
+          height: 16px;
         }
       }
 


### PR DESCRIPTION
* Adjusted position of magnifying glass icon on submit button for high density screens
* Fixed height of search box on mobile to match height of submit button
* Adjusted height of button to even number for general height matching
* Fixes #183

**Before, desktop**
<img width="623" alt="screen shot 2017-05-24 at 15 28 13" src="https://cloud.githubusercontent.com/assets/861310/26408419/a89d9132-4095-11e7-9e38-9a7bf96117c5.png">

**After, desktop**
<img width="621" alt="screen shot 2017-05-24 at 15 28 49" src="https://cloud.githubusercontent.com/assets/861310/26408451/bcae928e-4095-11e7-9158-c1beed71c8c3.png">

**Before, mobile**
<img width="343" alt="screen shot 2017-05-24 at 15 29 26" src="https://cloud.githubusercontent.com/assets/861310/26408478/d1d67406-4095-11e7-899c-2be3e4ecbb67.png">

**After, mobile**
<img width="341" alt="screen shot 2017-05-24 at 15 30 02" src="https://cloud.githubusercontent.com/assets/861310/26408511/e2b7e908-4095-11e7-9ee2-b18980367732.png">

Internet Explorer 9...

Before
<img width="618" alt="screen shot 2017-05-25 at 08 41 48" src="https://cloud.githubusercontent.com/assets/861310/26440871/20775446-4126-11e7-910b-970c6bb4cd22.png">

After:
<img width="623" alt="screen shot 2017-05-25 at 08 41 58" src="https://cloud.githubusercontent.com/assets/861310/26440878/29273ef8-4126-11e7-90fd-8d64ac43db0f.png">

The only difference I've made is that the input and the button are now both a little taller. It looks exactly the same in every newer version of IE as well.

I can fix this by explicitly setting a px height for the input (allowing for padding), but that feels wrong.
