### PR TITLE
Bump gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8.2'
 
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '~> 42.0.0'
+gem 'gds-api-adapters', '~> 46.0.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_navigation_helpers', '6.0.1'
+gem 'govuk_navigation_helpers', '6.3.0'
 gem 'govuk_ab_testing', '~> 2.1'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (42.0.0)
+    gds-api-adapters (46.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -84,8 +84,8 @@ GEM
     govuk_frontend_toolkit (1.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.0.1)
-      gds-api-adapters (~> 42.0)
+    govuk_navigation_helpers (6.3.0)
+      gds-api-adapters (>= 43.0)
     hashdiff (0.3.0)
     hike (1.2.3)
     http-cookie (1.0.3)
@@ -264,12 +264,12 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   better_errors
   binding_of_caller
-  gds-api-adapters (~> 42.0.0)
+  gds-api-adapters (~> 46.0.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk-lint
   govuk_ab_testing (~> 2.1)
   govuk_frontend_toolkit (= 1.2.0)
-  govuk_navigation_helpers (= 6.0.1)
+  govuk_navigation_helpers (= 6.3.0)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)


### PR DESCRIPTION
[Trello](https://trello.com/c/J8ofEnrt/167-display-curated-related-links-in-the-sidebar)

To keep up to date with:

- govuk_navigation_helpers (https://github.com/alphagov/govuk_navigation_helpers/blob/master/CHANGELOG.md#630)
- gds_api_adapters (https://github.com/alphagov/gds-api-adapters/blob/master/CHANGELOG.md#4600)