### PR TITLE
Fix inconsistent header appearance for manuals on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,7 +68,7 @@ main {
 
     padding: $gutter;
     color: $white;
-    margin: 0 (-$gutter-half);
+    margin: 0;
     @include core-16;
     @extend %contain-floats;
 
@@ -77,8 +77,6 @@ main {
     }
 
     @include media(tablet) {
-      margin: 0;
-
       .primary,
       .secondary {
         float: left;


### PR DESCRIPTION
- removing outer negative margin so box aligns with thin bar beneath header.
- https://trello.com/c/fOALAER3/5-global-header-bar-looks-odd-on-small-viewports-186
- fixes https://github.com/alphagov/manuals-frontend/issues/186

**Before**
<img width="580" alt="screen shot 2017-07-11 at 15 16 22" src="https://user-images.githubusercontent.com/861310/28072827-03f8fdec-664c-11e7-8dd3-2cb8904ed7d0.png">

**After**
<img width="581" alt="screen shot 2017-07-11 at 15 16 41" src="https://user-images.githubusercontent.com/861310/28072831-086c56a8-664c-11e7-984e-0d9fedb2caca.png">
