### PR TITLE
Remove unneeded paragraph padding from collapsible sections

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -303,10 +303,6 @@ main {
 
   .collapsible-subsections {
     @include media(tablet) {
-      p {
-        margin-top: $gutter-two-thirds;
-      }
-
       .call-to-action p {
         margin: 0;
       }


### PR DESCRIPTION
Adding padding to the top of `p` elements in collapsible subsections
adds extra padding to govspeak components like callouts, warnings, step
numbers, etc. which makes them render incorrectly.

This margin should not be required elsewhere, because govspeak `p`
elements have bottom margin. The margin at the top is covered by
the margin introduced by the body wrapper.

## Screenshots

### Before

![callout-before](https://user-images.githubusercontent.com/12036746/28262546-40d5f74a-6adb-11e7-8419-d994f4adfbe4.png)
![warning-before](https://user-images.githubusercontent.com/12036746/28262549-4419ea6a-6adb-11e7-8261-c32a08ae72d0.png)
![numbers-before](https://user-images.githubusercontent.com/12036746/28262555-467f231a-6adb-11e7-96c8-39d0eb01f108.png)

### After

![callout-after](https://user-images.githubusercontent.com/12036746/28262560-4e9c96cc-6adb-11e7-8c54-64f6ba334c0b.png)
![warning-after](https://user-images.githubusercontent.com/12036746/28262562-50fe8c5e-6adb-11e7-9dd6-f32ac11cdd93.png)
![numbers-after](https://user-images.githubusercontent.com/12036746/28262565-52996994-6adb-11e7-96e8-dd3c52b523bd.png)

## Zendesk

https://govuk.zendesk.com/agent/tickets/2260672