### PR TITLE
Fix caching problems and return 406 when necessary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.7.1'
-gem 'slimmer', '~> 10.1.3'
+gem 'slimmer', '~> 11.0.1'
 
 gem 'govuk_frontend_toolkit', '1.2.0'
 gem 'sass-rails', '~> 5.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,12 +118,12 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     minitest (5.10.1)
     multi_json (1.12.1)
     netrc (0.11.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     null_logger (0.0.1)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -214,10 +214,10 @@ GEM
     scss_lint (0.52.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
-    slimmer (10.1.3)
+    slimmer (11.0.1)
       activesupport
       json
-      nokogiri (>= 1.5.0, < 1.7.0)
+      nokogiri (~> 1.7)
       null_logger
       plek (>= 1.1.0)
       rack
@@ -279,11 +279,11 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0.6)
-  slimmer (~> 10.1.3)
+  slimmer (~> 11.0.1)
   statsd-ruby (= 1.3.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.2)
   webmock (~> 2.1.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 ManualsFrontend::Application.routes.draw do
-  with_options(constraints: { prefix: /(guidance|hmrc-internal-manuals)/ }) do |r|
-    r.get '/:prefix/:manual_id', to: 'manuals#index'
-    r.get '/:prefix/:manual_id/updates', to: 'manuals#updates'
-    r.get '/:prefix/:manual_id/:section_id', to: 'manuals#show'
+  scope constraints: { prefix: /(guidance|hmrc-internal-manuals)/, format: 'html' } do
+    get '/:prefix/:manual_id', to: 'manuals#index'
+    get '/:prefix/:manual_id/updates', to: 'manuals#updates'
+    get '/:prefix/:manual_id/:section_id', to: 'manuals#show'
   end
 
   root to: proc { [404, {}, ['Not found']] }


### PR DESCRIPTION
Slimmer is erroring under a certain set of inputs but catching the error – this leads to an invalid page being cached and served to users. By letting the error through we will serve a 500, the page will not be cached and users will see the correct content.

When a request is made for an unsupported format, eg text/javascript, the lack of a respond_to block meant we attempted to render it without a layout.

This led to a body being sent to slimmer without a #wrapper element,
causing the error:
`> undefined method 'to_html' for nil:NilClass`
in the BodyInserter processor

This matches: https://github.com/alphagov/finder-frontend/pull/271