### PR TITLE
Add current_path to the survey link in the beta banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,8 @@ module ApplicationHelper
 
     siblings
   end
+
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
 end

--- a/app/views/manuals/_taxonomy_beta_label.html.erb
+++ b/app/views/manuals/_taxonomy_beta_label.html.erb
@@ -4,7 +4,7 @@
     locals: {
       message: <<-MESSAGE
       This is a test version of the layout of this page.
-      <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017' target='_blank' rel='noopener noreferrer'>
+      <a id=taxonomy-survey href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}' target='_blank' rel='noopener noreferrer'>
         Take the survey to help us improve it
       </a>
       MESSAGE

--- a/spec/unit/application_helper_spec.rb
+++ b/spec/unit/application_helper_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.marked_up_date(Date.today)).to match(%r{^<time.*</time>})
     end
   end
+
+  describe '#current_path_without_query_string' do
+    it "returns the path of the current request" do
+      allow(helper).to receive(:request).and_return(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar'))
+      expect(helper.current_path_without_query_string).to eq('/foo/bar')
+    end
+
+    it "returns the path of the current request stripping off any query string parameters" do
+      allow(helper).to receive(:request).and_return(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+      expect(helper.current_path_without_query_string).to eq('/foo/bar')
+    end
+  end
 end


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

This lets the survey team know where each response has come from and
allows them to filter by section of the site.