### PR TITLE
Allow HMRC manuals to be indexed

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -5,7 +5,6 @@ class ManualsController < ApplicationController
 
   before_action :ensure_manual_is_found
   before_action :ensure_document_is_found, only: :show
-  before_action :prevent_robots_from_indexing_hmrc_manuals
   before_action :set_up_education_navigation_ab_testing
 
   def index
@@ -104,10 +103,6 @@ private
 
   def document_id
     params["section_id"]
-  end
-
-  def prevent_robots_from_indexing_hmrc_manuals
-    response.headers["X-Robots-Tag"] = "none" if manual.hmrc?
   end
 
   def set_expiry(content_item)

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -32,14 +32,12 @@ feature "Viewing manuals and sections" do
   scenario "viewing a non-HMRC manual" do
     stub_fake_manual
     visit_manual "my-manual-about-burritos"
-    expect(page.response_headers['X-Robots-Tag']).not_to eq("none")
     expect_no_component('beta_label')
   end
 
   scenario "viewing an HMRC manual" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
-    expect(page.response_headers['X-Robots-Tag']).to eq("none")
     expect_component('beta_label')
   end
 


### PR DESCRIPTION
We are now the canonical source of data on HMRC manuals, as such
we should index the data in external search engines.

https://trello.com/c/47KVsqpb/290-hmrc-manuals-in-external-search