### PR TITLE
Send update_type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '4.8.2'
 
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '~> 46.0.0'
+gem 'gds-api-adapters', '~> 49.0'
 
 gem 'airbrake', '4.0.0'
 gem 'logstasher', '0.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (46.0.0)
+    gds-api-adapters (49.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -142,8 +142,8 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (1.6.5)
-    rack-cache (1.7.0)
+    rack (1.6.8)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -264,7 +264,7 @@ DEPENDENCIES
   airbrake (= 4.0.0)
   better_errors
   binding_of_caller
-  gds-api-adapters (~> 46.0.0)
+  gds-api-adapters (~> 49.0)
   govuk-content-schema-test-helpers (~> 1.5)
   govuk-lint
   govuk_ab_testing (~> 2.1)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -24,11 +24,12 @@ class RedirectPublisher
           "type" => type,
           "destination" => destination_path
         }
-      ]
+      ],
+      "update_type" => "major",
     }
 
     publishing_api.put_content(content_id, redirect)
-    publishing_api.publish(content_id, 'major')
+    publishing_api.publish(content_id)
   end
 
 private


### PR DESCRIPTION
It will soon be a requirement to send `update_type` with PUT content requests to the Publishing API, and sending `update_type` with Publish request is being deprecated.  In this PR we update PUT content and Publish requests in preparation for this change.  We also upgrade `gds-api-adapters` to bring this app up to date with the new expected behaviour.

[Trello](https://trello.com/c/LnJlkb9e/29-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)