### PR TITLE
Load `/lib`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module ManualsFrontend
 
     config.load_defaults 5.1
 
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths << "#{config.root}/lib"
 
     config.assets.prefix = '/manuals-frontend'
 


### PR DESCRIPTION
This commit changes `autoload_paths` to `eager_load_paths` when loading
`/lib` to ensure that this is loaded as it currently isn't being correctly loaded when run in `production` env.