### PR TITLE
Run manuals publisher end to end tests downstream job as part of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
 node {
-  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject()
+  def govuk = load "/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy"
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-manuals-publisher")
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
Hey :wave: !

This PR will enable a set of [end-to-end tests](https://github.com/alphagov/publishing-e2e-tests) to run every time a commit is made to this repo. :boom:

You can read through the scenarios at a [high level](https://docs.google.com/document/d/164Y8IEhPKawPo0VyTk5nmU_J6JFnRuA7iwOFgmu98ok/edit), and the capybara [here](https://github.com/alphagov/publishing-e2e-tests/tree/master/spec/manuals_publisher).

Look at the merge box below and you'll see a new check performed on this PR.

![image](https://user-images.githubusercontent.com/976274/33369450-8d36f00a-d4ec-11e7-845c-690420f1b801.png)

Enabling these tests will give increased confidence when making changes to this repo that the change doesn't break the publisher in an end-to-end environment.   The downside is that running these tests takes time, with build times between 6 - 11 minutes currently.