### PR TITLE
Bump components gem to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'gds-api-adapters', '~> 50.8'
 
 gem 'logstasher', '0.6.2'
 
-gem 'govuk_publishing_components', '~> 3.0.2'
+gem 'govuk_publishing_components', '~> 3.2.0'
 gem 'govuk_navigation_helpers', '8.1.1'
 gem 'govuk_app_config', '~> 0.3.0'
 gem 'govuk_ab_testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       rest-client (~> 2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    govspeak (5.2.2)
+    govspeak (5.3.0)
       actionview (>= 4.1, < 6)
       addressable (>= 2.3.8, < 3)
       commander (~> 4.4)
@@ -111,7 +111,7 @@ GEM
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
-    govuk_publishing_components (3.0.2)
+    govuk_publishing_components (3.2.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -222,7 +222,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.0.0)
+    rouge (3.1.0)
     rspec-core (3.7.0)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -322,7 +322,7 @@ DEPENDENCIES
   govuk_app_config (~> 0.3.0)
   govuk_frontend_toolkit (= 7.2.0)
   govuk_navigation_helpers (= 8.1.1)
-  govuk_publishing_components (~> 3.0.2)
+  govuk_publishing_components (~> 3.2.0)
   jasmine-rails
   launchy
   logstasher (= 0.6.2)


### PR DESCRIPTION
Mainly for the new print styles for task lists.
  
Trello card: https://trello.com/c/9CD3dY7r/409-add-task-list-print-styles-to-apps