### PR TITLE
Upgrade to govuk_app_config v 1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,12 @@ gem 'govuk_frontend_toolkit', '7.2.0'
 gem 'sass-rails', '~> 5.0.6'
 gem 'uglifier', '>= 1.3.0'
 
-gem 'unicorn', '5.4.0'
-
 gem 'plek', '2.0.0'
 gem 'gds-api-adapters', '~> 51.0'
 
-gem 'logstasher', '0.6.2'
-
 gem 'govuk_publishing_components', '~> 4.1.0'
 gem 'govuk_navigation_helpers', '8.1.1'
-gem 'govuk_app_config', '~> 0.3.0'
+gem 'govuk_app_config', '~> 1.2.0'
 gem 'govuk_ab_testing'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,9 +102,11 @@ GEM
       rubocop-rspec (~> 1.19.0)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (0.3.0)
-      sentry-raven (~> 2.6.3)
+    govuk_app_config (1.2.1)
+      logstasher (~> 1.2.2)
+      sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
+      unicorn (~> 5.4.0)
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
@@ -140,9 +142,10 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
-    logstash-event (1.1.5)
-    logstasher (0.6.2)
-      logstash-event (~> 1.1.0)
+    logstash-event (1.2.02)
+    logstasher (1.2.2)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
       request_store
     loofah (2.1.1)
       crass (~> 1.0.2)
@@ -218,7 +221,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -268,7 +272,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    sentry-raven (2.6.3)
+    sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     slimmer (11.1.1)
       activesupport
@@ -320,13 +324,12 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_ab_testing
-  govuk_app_config (~> 0.3.0)
+  govuk_app_config (~> 1.2.0)
   govuk_frontend_toolkit (= 7.2.0)
   govuk_navigation_helpers (= 8.1.1)
   govuk_publishing_components (~> 4.1.0)
   jasmine-rails
   launchy
-  logstasher (= 0.6.2)
   plek (= 2.0.0)
   poltergeist (= 1.17.0)
   pry-byebug
@@ -335,7 +338,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.6)
   slimmer (~> 11.1.1)
   uglifier (>= 1.3.0)
-  unicorn (= 5.4.0)
   webmock (~> 3.2.1)
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,12 +73,4 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Logstasher config
-  $real_stdout = $stdout.clone
-  $stdout.reopen($stderr)
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new($real_stdout)
-  config.logstasher.view_enabled = false
-  config.logstasher.suppress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,8 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-  end
-end


### PR DESCRIPTION
We follow the guide in the changelog for govuk_app_config for going to
1.0.  We also remove the following stanza from config/production.rb:

    $real_stdout = $stdout.clone
    $stdout.reopen($stderr)

It's not mentioned in the govuk_app_config readme, but those lines are in
govuk_app_config now, so I suspect we don't need them in ours.