### PR TITLE
Use foreman to run application in docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
-
 RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME manuals-frontend
 ENV PORT 3072
@@ -19,4 +19,4 @@ ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
-CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3072}


### PR DESCRIPTION
Wider context: alphagov/publishing-e2e-tests#202

Foreman is installed via a gem rather than bundle install due to the
somewhat contentious instructions on the foreman readme - this also has
the advantage of isolating this from the app.