### PR TITLE
Render step nav content from content item

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,15 +10,11 @@ class ApplicationController < ActionController::Base
 
   before_action :slimmer_headers
 
-  def current_step_nav
-    @step_nav ||= GovukNavigationHelpers::StepNavContent.current_step_nav(request.path)
+  def step_nav_helper
+    @step_nav_helper ||= GovukPublishingComponents::StepNavHelper.new(content_store_manual,
+      request.path)
   end
-  helper_method :current_step_nav
-
-  def show_step_nav?
-    current_step_nav && current_step_nav.show_step_nav?
-  end
-  helper_method :show_step_nav?
+  helper_method :step_nav_helper
 
 private
 

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -6,14 +6,11 @@
   )
 %>
 
-<% if show_step_nav? %>
-  <%= render "govuk_publishing_components/components/step_by_step_nav_header", {
-    title: current_step_nav.title,
-    path: current_step_nav.base_path
-  } %>
+<% if step_nav_helper.show_header? %>
+  <%= render "govuk_publishing_components/components/step_by_step_nav_header", step_nav_helper.header %>
 <% end %>
 
-<% if presented_manual.beta? && !show_step_nav? %>
+<% if presented_manual.beta? %>
   <div class='manual-in-beta'>
     <%= render partial: 'govuk_component/beta_label' %>
   </div>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -10,7 +10,7 @@ feature "Viewing manuals and sections" do
 
   context "step by step navigation" do
     scenario "viewing something not in the step by step navigation" do
-      stub_fake_manual(base_path: '/guidance/the-green-cross-code')
+      stub_fake_manual(base_path: '/guidance/the-green-cross-code', include_step_nav: false)
 
       visit_manual('the-green-cross-code')
 
@@ -18,7 +18,7 @@ feature "Viewing manuals and sections" do
     end
 
     scenario "viewing The Highway Code manual (as it's in the step navigation)" do
-      stub_fake_manual(base_path: '/guidance/the-highway-code')
+      stub_fake_manual(base_path: '/guidance/the-highway-code', include_step_nav: true)
 
       visit_manual('the-highway-code')
 

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -16,7 +16,13 @@ module ManualHelpers
     ).fetch("links")
   end
 
-  def stub_fake_manual(base_path: "/guidance/my-manual-about-burritos", public_updated_at: "2014-06-20T10:17:29+01:00", first_published_at: "2009-02-20T15:31:09+00:00")
+  def example_step_nav_links
+    JSON.parse(
+      GovukContentSchemaTestHelpers::Examples.new.get('manual', 'manual-with-step-navs')
+    ).fetch("links")
+  end
+
+  def stub_fake_manual(base_path: "/guidance/my-manual-about-burritos", include_step_nav: false, public_updated_at: "2014-06-20T10:17:29+01:00", first_published_at: "2009-02-20T15:31:09+00:00")
     manual_json = {
       base_path: base_path,
       title: "My manual about Burritos",
@@ -24,7 +30,7 @@ module ManualHelpers
       format: "manual",
       first_published_at: first_published_at,
       public_updated_at: public_updated_at,
-      links: example_links,
+      links: include_step_nav ? example_step_nav_links : example_links,
       details: {
         child_section_groups: [
           {


### PR DESCRIPTION
Step by step navigation content is now held in content items.  The helpers have
been updated appropriately, and are now held in govuk_publishing_components as
they are so tightly coupled to the components themselves.

https://trello.com/c/aHTclade/443-manuals-frontend-renders-step-by-step-navigation-from-content-item