### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
   <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
-  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_store_manual } %>
+  <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_store_manual %>
   <%= yield :extra_head_content %>
 </head>
 <body>


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/2w1AKyuW