### PR TITLE
Handle nil titles

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -19,10 +19,13 @@ class Manual
   end
 
   def full_title
+    title = content_store_manual['title'] || ''
+    title += ' - ' unless title.blank?
+
     if hmrc?
-      content_store_manual['title'] + ' - HMRC internal manual'
+      title + 'HMRC internal manual'
     else
-      content_store_manual['title'] + ' - Guidance'
+      title + 'Guidance'
     end
   end
 

--- a/spec/unit/manual_spec.rb
+++ b/spec/unit/manual_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Manual do
     it 'does not think it is a beta manual' do
       expect(subject.beta?).to eq false
     end
+
+    it 'suffixes the full title' do
+      expect(subject.full_title).to eq('My manual about Burritos - Guidance')
+    end
   end
 
   context 'for an HMRC manual' do
@@ -32,6 +36,12 @@ RSpec.describe Manual do
 
     it 'knows it is a beta manual' do
       expect(subject.beta?).to eq true
+    end
+
+    context '#full_title' do
+      it 'uses the correct suffix' do
+        expect(subject.full_title).to eq('Inheritance Tax Manual - HMRC internal manual')
+      end
     end
   end
 


### PR DESCRIPTION
https://sentry.io/govuk/app-manuals-frontend/

We've seen a [bunch of errors in Sentry](https://sentry.io/govuk/app-manuals-frontend/issues/529442718) where `content_store_manual` does not have a title.

The root cause is that content item doesn't have a title, this is possibly something wrong upstream with the data [hmrc-manuals-api](https://github.com/alphagov/hmrc-manuals-api) receives from HMRC.

```
irb(main):006:0> ContentItem.where(id: "/hmrc-internal-manuals/vat-civil-evasion-penalty").first
=> #<ContentItem _id: /hmrc-internal-manuals/vat-civil-evasion-penalty,  ... title: nil, description:
```