### PR TITLE
Add schema and SEO things to manuals

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -73,6 +73,14 @@ private
     end
   end
 
+  def content_store_section
+    @content_store_section ||= begin
+      Services.content_store.content_item(document_base_path)
+    rescue GdsApi::ContentStore::ItemNotFound
+      nil
+    end
+  end
+
   def manual
     @manual = Manual.new(content_store_manual)
   end
@@ -87,7 +95,7 @@ private
 
   def document_from_repository
     @document_from_repository ||=
-      DocumentRepository.new.fetch(document_base_path)
+      DocumentRepository.new.fetch(content_store_section)
   end
 
   def document_base_path

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -1,7 +1,5 @@
 class DocumentRepository
-  def fetch(base_path)
-    document = fetch_content_item(base_path)
-
+  def fetch(document)
     if document
       parent = fetch_parent_for_document(document)
 

--- a/app/views/manuals/_content_for_head_tag.html.erb
+++ b/app/views/manuals/_content_for_head_tag.html.erb
@@ -2,6 +2,15 @@
   <% if description.present? %>
     <meta name='description' content='<%= description %>' />
   <% end %>
+
+  <% if @content_store_section %>
+    <%= render 'govuk_publishing_components/components/machine_readable_metadata',
+      schema: :article,
+      content_item: @content_store_section,
+      title: title,
+      description: description
+    %>
+  <% end %>
 <% end %>
 
 <% content_for :title, title %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -1,7 +1,7 @@
 <%=
   render(
     'content_for_head_tag',
-    description: presented_manual.summary,
+    description: presented_document.summary,
     title: presented_document.full_title,
   )
 %>


### PR DESCRIPTION
This adds the Machine readable metadata component, which adds Schema.org data, a canonical tag and Twitter/Facebook meta tags.

https://trello.com/c/gKHoUGuA