### PR TITLE
Use phase banner from gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.0'
-gem 'slimmer', '~> 12.1.0'
+gem 'slimmer', '~> 13.0.0'
 
 gem 'govuk_frontend_toolkit', '7.5.0'
 gem 'sass-rails', '~> 5.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       sass (~> 3.5.5)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.1.0)
+    slimmer (13.0.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -344,7 +344,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0.6)
-  slimmer (~> 12.1.0)
+  slimmer (~> 13.0.0)
   uglifier (>= 1.3.0)
   webmock (~> 3.4.2)
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,12 +20,6 @@ main {
 .manuals-frontend-body {
   padding-bottom: $gutter;
 
-  .manual-in-beta {
-    .govuk-beta-label {
-      border-bottom: none;
-    }
-  }
-
   header {
     background: $govuk-blue;
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  include Slimmer::GovukComponents
-
   before_action :slimmer_headers
 
 private

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,6 +1,6 @@
 <% if presented_manual.beta? %>
   <div class='manual-in-beta'>
-    <%= render partial: 'govuk_component/beta_label' %>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
   </div>
 <% end %>
 

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,7 +1,5 @@
 <% if presented_manual.beta? %>
-  <div class='manual-in-beta'>
-    <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
-  </div>
+  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 
 <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_store_manual %>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,3 +1,9 @@
+<% if presented_manual.beta? %>
+  <div class='manual-in-beta'>
+    <%= render partial: 'govuk_component/beta_label' %>
+  </div>
+<% end %>
+
 <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_store_manual %>
 
 <header aria-labelledby="manual-title" class="<%= presented_manual.hmrc? ? 'hmrc' : nil %>">

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -6,11 +6,6 @@
   )
 %>
 
-<% if presented_manual.beta? %>
-  <div class='manual-in-beta'>
-    <%= render partial: 'govuk_component/beta_label' %>
-  </div>
-<% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%= render 'manual_breadcrumbs', presented_manual: presented_manual %>
 <%= render 'manual', presented_manual: presented_manual %>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -5,11 +5,6 @@
     title: presented_document.full_title,
   )
 %>
-<% if presented_manual.beta? %>
-  <div class='manual-in-beta'>
-    <%= render partial: 'govuk_component/beta_label' %>
-  </div>
-<% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%=
   render(

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -5,11 +5,6 @@
     title: 'Updates - ' + presented_manual.full_title,
   )
 %>
-<% if presented_manual.beta? %>
-  <div class='manual-in-beta'>
-    <%= render partial: 'govuk_component/beta_label' %>
-  </div>
-<% end %>
 <%= render 'header', presented_manual: presented_manual %>
 <%=
   render(

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -33,13 +33,13 @@ feature "Viewing manuals and sections" do
   scenario "viewing a non-HMRC manual" do
     stub_fake_manual
     visit_manual "my-manual-about-burritos"
-    expect_no_component('beta_label')
+    expect(page).not_to have_selector('.gem-c-phase-banner')
   end
 
   scenario "viewing an HMRC manual" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
-    expect_component('beta_label')
+    expect(page).to have_selector('.gem-c-phase-banner')
   end
 
   scenario "viewing a manual with a description" do

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -89,23 +89,6 @@ module AppHelpers
       expect(page).to have_content(change_note)
     end
   end
-
-  def expect_component(component_type, in_scope: nil)
-    component_selector = shared_component_selector(component_type)
-    component_selector = "#{in_scope} #{component_selector}" if in_scope.present?
-    if block_given?
-      within(component_selector) do
-        component_details = JSON.parse(page.text)
-        yield component_details
-      end
-    else
-      expect(page).to have_selector(component_selector)
-    end
-  end
-
-  def expect_no_component(component_type)
-    expect(page).not_to have_selector(shared_component_selector(component_type))
-  end
 end
 
 RSpec.configuration.include AppHelpers, type: :feature


### PR DESCRIPTION
This makes the app use the phase banner from the gem (https://trello.com/c/qtXCDGQI). Since this is the last usage of Static components, we can clean up the code and test helpers.

https://trello.com/c/pU7YINt1