### PR TITLE
Remove rich_govspeak option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'plek', '2.1.1'
 gem 'gds-api-adapters', '~> 52.7'
 
-gem 'govuk_publishing_components', '~> 9.9.1'
+gem 'govuk_publishing_components', '~> 9.10.0'
 gem 'govuk_app_config', '~> 1.7.0'
 gem 'govuk_ab_testing'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.9.1)
+    govuk_publishing_components (9.10.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -335,7 +335,7 @@ DEPENDENCIES
   govuk_ab_testing
   govuk_app_config (~> 1.7.0)
   govuk_frontend_toolkit (= 7.6.0)
-  govuk_publishing_components (~> 9.9.1)
+  govuk_publishing_components (~> 9.10.0)
   jasmine
   launchy
   plek (= 2.1.1)
@@ -349,4 +349,4 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -21,9 +21,7 @@
       <% if presented_document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= presented_document.collapse_depth %>>
           <div class='collapsible-subsections'>
-            <%= render 'govuk_publishing_components/components/govspeak',
-              content: presented_document.body,
-              rich_govspeak: true %>
+            <%= render 'govuk_publishing_components/components/govspeak', content: presented_document.body %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
https://trello.com/c/BUij6N3Y/361-turn-on-bold-for-whitehall

Rich govpseak will be enabled by default.

Depends on: https://github.com/alphagov/govuk_publishing_components/pull/463