### PR TITLE
Remove strong elements from reset to enable bold

### DIFF
--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -22,7 +22,7 @@ time, mark {
 }
 
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-small, strike, strong, sub, sup, tt, var,
+small, strike, sub, sup, tt, var,
 b, u, i, center,
 input, textarea,
 table, caption, tbody, tfoot, thead, tr, th, td {


### PR DESCRIPTION
https://trello.com/c/BUij6N3Y/361-turn-on-bold-for-whitehall

Removes explicit reset of `<strong>` elements.

Related to https://github.com/alphagov/manuals-frontend/pull/436, the `.rich-govspeak` class would override this reset.