### PR TITLE
Replace poltergeist with govuk test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ group :development, :test do
 end
 
 group :test do
+  gem "govuk_test"
   gem "webmock", "~> 3.4.2"
-  gem "poltergeist", "1.17.0"
   gem "launchy"
   gem "govuk-content-schema-test-helpers", "~> 1.6"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     better_errors (2.5.0)
@@ -54,14 +56,18 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (9.1.0)
-    capybara (2.16.1)
+    capybara (3.7.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    cliver (0.3.2)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     commander (4.4.6)
       highline (~> 1.7.2)
@@ -121,6 +127,11 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
+    govuk_test (0.1.0)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -128,6 +139,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jasmine (3.2.0)
       jasmine-core (= 3.2.0)
@@ -178,10 +190,6 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -190,6 +198,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -260,6 +269,7 @@ GEM
     rubocop-rspec (1.29.0)
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
       crass (~> 1.0.2)
@@ -279,6 +289,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     slimmer (13.0.0)
@@ -318,8 +331,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -334,10 +347,10 @@ DEPENDENCIES
   govuk_app_config (~> 1.8.0)
   govuk_frontend_toolkit (= 7.6.0)
   govuk_publishing_components (~> 9.16.0)
+  govuk_test
   jasmine
   launchy
   plek (= 2.1.1)
-  poltergeist (= 1.17.0)
   pry-byebug
   rails (~> 5.2.1)
   rspec-rails (~> 3.8)

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -109,7 +109,7 @@ feature "Viewing manuals and sections" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
 
-    expect_page_to_include_section("EIM00100 About this manual")
+    expect_page_to_include_section(/EIM00100\WAbout this manual/)
     expect_page_to_include_section("EIM00500 Inheritance tax",
                                    href: "/hmrc-internal-manuals/inheritance-tax-manual/eim00500")
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,0 @@
-require 'capybara/poltergeist'
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--ssl-protocol=TLSv1'])
-end
-
-Capybara.javascript_driver = :poltergeist

--- a/spec/support/govuk_test.rb
+++ b/spec/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Poltergeist is no longer maintained so switch to Capybara::RackTest and where applicable Selenium chrome headless driver via alphagov/govuk_test.