### PR TITLE
Override link colour in metadata component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,18 @@ header .gem-c-metadata {
   header {
     background: $govuk-blue;
 
+    // FIXME this is to fix link colours in the metadata component on a
+    // blue background. This can be removed once the component has been
+    // updated to accommodate such a situation
+    .gem-c-metadata a,
+    .gem-c-metadata a:link,
+    .gem-c-metadata a:hover,
+    .gem-c-metadata a:active,
+    .gem-c-metadata a:visited {
+      color: govuk-colour('white');
+    }
+
+
     &.hmrc {
       background: $hm-revenue-customs;
     }


### PR DESCRIPTION
- assumes a white background but the component is used on a blue background so links are invisible
- this is a short term fix while we get the component updated to have an option to allow for this scenario

Fixes this:

![screen shot 2018-12-04 at 10 47 42](https://user-images.githubusercontent.com/861310/49436864-10080300-f7b2-11e8-932b-4dd6aa1cae61.png)

Example demo URL (fixed): https://govuk-manuals-frontend-pr-531.herokuapp.com/guidance/prevent-groundwater-pollution-from-underground-fuel-storage-tanks

Example live URL (broken): https://www.gov.uk/guidance/prevent-groundwater-pollution-from-underground-fuel-storage-tanks
