### PR TITLE
Use inverse metadata option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'plek', '2.1.1'
 
 gem 'govuk_ab_testing'
 gem 'govuk_app_config', '~> 1.10.0'
-gem 'govuk_publishing_components', '~> 12.14.1'
+gem 'govuk_publishing_components', '~> 12.18.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (12.14.1)
+    govuk_publishing_components (12.18.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -189,7 +189,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     null_logger (0.0.1)
-    oj (3.7.1)
+    oj (3.7.4)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -353,7 +353,7 @@ DEPENDENCIES
   govuk_ab_testing
   govuk_app_config (~> 1.10.0)
   govuk_frontend_toolkit (= 8.1.0)
-  govuk_publishing_components (~> 12.14.1)
+  govuk_publishing_components (~> 12.18.0)
   govuk_test
   jasmine
   launchy

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,27 +17,11 @@ main {
   display: block;
 }
 
-header .gem-c-metadata {
-  color: $white;
-}
-
 .manuals-frontend-body {
   padding-bottom: $gutter;
 
   header {
     background: $govuk-blue;
-
-    // FIXME this is to fix link colours in the metadata component on a
-    // blue background. This can be removed once the component has been
-    // updated to accommodate such a situation
-    .gem-c-metadata a,
-    .gem-c-metadata a:link,
-    .gem-c-metadata a:hover,
-    .gem-c-metadata a:active,
-    .gem-c-metadata a:visited {
-      color: govuk-colour('white');
-    }
-
 
     &.hmrc {
       background: $hm-revenue-customs;

--- a/app/presenters/manual_presenter.rb
+++ b/app/presenters/manual_presenter.rb
@@ -25,7 +25,8 @@ class ManualPresenter < SimpleDelegator
       first_published: @view_context.marked_up_date(first_published_at),
       other: {
         "Updated" => "#{updated_at}, #{@view_context.link_to 'see all updates', updates_url}",
-      }
+      },
+      inverse: true
     }
   end
 end


### PR DESCRIPTION
Use the [inverse option](https://github.com/alphagov/govuk_publishing_components/pull/657) for the metadata component to provide a more robust solution to [this PR](https://github.com/alphagov/manuals-frontend/pull/531).