### PR TITLE
Add all JavaScript dependencies from govuk_publishing_components

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,5 @@
+//= require govuk_publishing_components/all_components
 //= require_tree ./modules
-//= require govuk_publishing_components/components/feedback
 // from govuk_frontend_toolkit and not delivered by static as part of
 // header-footer-only on deployed environments
 //= require govuk/primary-links


### PR DESCRIPTION
This is one of the few remaining apps that don't require all scripts form govuk_publishing_components.