### PR TITLE
Add machine readable metadata to manuals

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -7,6 +7,7 @@ class ManualsController < ApplicationController
 
     render :index, locals: {
       presented_manual: presented_manual,
+      content_item: content_store_manual
     }
   end
 

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -6,6 +6,10 @@
   )
 %>
 
+<%= render 'govuk_publishing_components/components/machine_readable_metadata',
+           schema: :article,
+           content_item: content_item %>
+
 <%= render 'header', presented_manual: presented_manual %>
 <%= render 'manual_breadcrumbs', presented_manual: presented_manual %>
 <%= render 'manual', presented_manual: presented_manual %>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -28,6 +28,8 @@ feature "Viewing manuals and sections" do
 
     expect_page_to_be_affiliated_with_org(title: "HM Revenue & Customs",
                                           slug: "hm-revenue-customs")
+
+    expect_page_to_have_machine_readable_metadata("Inheritance Tax Manual")
   end
 
   scenario "viewing a non-HMRC manual" do

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -92,6 +92,17 @@ module AppHelpers
       expect(page).to have_content(change_note)
     end
   end
+
+  def expect_page_to_have_machine_readable_metadata(title)
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    org_schema = schemas.detect { |schema| schema["@type"] == "Article" }
+    expect(org_schema["headline"]).to eq title
+
+    tag = "link[rel='canonical']"
+    expect(page).to have_css(tag, visible: false)
+  end
 end
 
 RSpec.configuration.include AppHelpers, type: :feature


### PR DESCRIPTION
This adds the standard `Article` schema to the manual page (not sections
as yet).

We may look at adding the `HasPart` and `IsPartOf` schemas to manuals and
sections, but we'll plan this separately.

Adding a `SearchAction` to manuals pages is coming soon, and will happen
automatically when the publishing components gem is updated with the changes.

You can check that this works by looking at: https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgovuk-manuals-frontend-pr-649.herokuapp.com%2Fguidance%2Fthe-highway-code which analyses the review app's highway code manual page.

https://trello.com/c/4EAytHVV/747-plan-indexing-of-finder-pages