### PR TITLE
Accordion accessibility fixes

### DIFF
--- a/app/assets/javascripts/modules/collapsible.js
+++ b/app/assets/javascripts/modules/collapsible.js
@@ -5,26 +5,39 @@
   function Collapsible(section){
     this.$section = section;
     this.$clickTarget = this.$section.find('.js-subsection-title');
-    this.$clickTarget.on('click', this.toggle.bind(this));
-    this.addToggle();
+    this.$button = this.$section.find('.js-section-button')[0];
 
+    this.$clickTarget.on('click', this.handleClick.bind(this));
+    this.addToggle();
     this.$section.on('focus', '.js-subsection-body a', this.showSectionWhenLinkFocused.bind(this));
   }
 
-  Collapsible.prototype.showSectionWhenLinkFocused = function() {
+  Collapsible.prototype.handleClick = function handleClick(){
+    this.toggle()
+    this.updateAriaAttribute(this.$button)
+  };
+
+  Collapsible.prototype.updateAriaAttribute = function updateAriaAttribute($button, state){
+    if (state) {
+      $button.setAttribute('aria-expanded', state);
+    } else {
+      $button.getAttribute('aria-expanded') === 'false' ?  $button.setAttribute('aria-expanded', 'true') : $button.setAttribute('aria-expanded', 'false');
+    }
+  };
+
+  Collapsible.prototype.showSectionWhenLinkFocused = function showSectionWhenLinkFocused() {
     if (this.$section.is('.closed')) {
       this.$section.toggleClass('closed');
     }
   };
 
   Collapsible.prototype.addToggle = function addToggle(){
-    var $toggleHTML = $("<span class='js-toggle'></span>");
+    var $toggleHTML = $("<span class='js-toggle' aria-hidden='true'></span>");
     this.$clickTarget.append($toggleHTML);
   };
 
-  Collapsible.prototype.toggle = function toggle(event){
+  Collapsible.prototype.toggle = function toggle(){
     this.$section.toggleClass('closed');
-    event.preventDefault();
   };
 
   Collapsible.prototype.close = function close(){
@@ -35,7 +48,7 @@
     this.$section.removeClass('closed');
   };
 
-  Collapsible.prototype.isClosed = function(){
+  Collapsible.prototype.isClosed = function isClosed(){
     return this.$section.hasClass('closed');
   };
 

--- a/app/assets/javascripts/modules/collapsible_collection.js
+++ b/app/assets/javascripts/modules/collapsible_collection.js
@@ -18,8 +18,8 @@
 
     if(this.$sections.length > 0) {
       this.$sections.each(this.initCollapsible.bind(this));
-      this.$openAll = $("<a href='#' aria-hidden=true>Open all</a>");
-      this.$closeAll = $("<a href='#' aria-hidden=true>Close all</a>");
+      this.$openAll = $("<button>Open all</button>");
+      this.$closeAll = $("<button>Close all</button>");
       this.addControls();
 
       this.closeAll();
@@ -65,7 +65,7 @@
     var subsectionHeaders = this.$container.find(this.collapseSelector);
     subsectionHeaders.each(function() {
       var $header = $(this);
-      $header.addClass('js-subsection-title').wrapInner('<a role="button" href="#' + $header.attr('id') + '"></a>');
+      $header.addClass('js-subsection-title').wrapInner('<button class="js-section-button" aria-expanded="false"></button>');
     });
 
     subsectionHeaders.each(function(index, el){
@@ -96,30 +96,24 @@
     return selector;
   };
 
-  CollapsibleCollection.prototype.closeAll = function closeAll(event){
+  CollapsibleCollection.prototype.closeAll = function closeAll(){
     for (var section in this.collapsibles) {
       this.collapsibles[section].close();
+      this.collapsibles[section].updateAriaAttribute(this.collapsibles[section].$button, 'false');
     }
 
     this.disableControl(this.$closeAll);
     this.enableControl(this.$openAll);
-
-    if (typeof event != 'undefined'){
-      event.preventDefault();
-    }
   };
 
-  CollapsibleCollection.prototype.openAll = function openAll(event){
+  CollapsibleCollection.prototype.openAll = function openAll(){
     for (var section in this.collapsibles) {
       this.collapsibles[section].open();
+      this.collapsibles[section].updateAriaAttribute(this.collapsibles[section].$button, 'true');
     }
 
     this.disableControl(this.$openAll);
     this.enableControl(this.$closeAll);
-
-    if (typeof event != 'undefined'){
-      event.preventDefault();
-    }
   };
 
   CollapsibleCollection.prototype.addControls = function addControls(){
@@ -161,11 +155,11 @@
   };
 
   CollapsibleCollection.prototype.disableControl = function disableControl(control){
-    control.addClass('disabled');
+    control.addClass('disabled').attr('disabled', 'disabled');
   };
 
   CollapsibleCollection.prototype.enableControl = function enableControl(control){
-    control.removeClass('disabled');
+    control.removeClass('disabled').removeAttr('disabled');
   };
 
   CollapsibleCollection.prototype.openCollapsibleForAnchor = function openCollapsibleForAnchor(anchor){

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,16 @@
 $manual-search-button-colour: #0b0c0c;
 $manual-search-button-border-colour: #222;
 
+%common-button-styles {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: 100%;
+  border-width: 0;
+  color: $govuk-blue;
+  background: none;
+  cursor: pointer;
+}
+
 main {
   display: block;
 }
@@ -278,8 +288,15 @@ main {
     margin: $gutter 0;
     position: relative;
 
-    a {
-      text-decoration: none;
+    button {
+      @extend %common-button-styles;
+      font-weight: 700;
+      margin-top: 0;
+      margin-bottom: 0;
+      margin-left: 0;
+      padding-bottom: 0;
+      padding-left: 0;
+      text-align: left;
     }
   }
 
@@ -312,8 +329,9 @@ main {
           display: inline-block;
         }
 
-        a {
+        button {
           @include core-16;
+          @extend %common-button-styles;
           padding: 0  5px 0 5px;
           display: inline-block;
 

--- a/spec/javascripts/collapsible_collection_spec.js
+++ b/spec/javascripts/collapsible_collection_spec.js
@@ -96,7 +96,7 @@ describe('CollapsibleCollection', function(){
       var html = $(collectionsFromBlobString);
       expect(html.find('a.collection-control').length).toBe(0);
       var collection = new GOVUK.CollapsibleCollection({$el:html});
-      expect(collection.$container.find('.js-collection-controls a').length).toBe(2);
+      expect(collection.$container.find('.js-collection-controls button').length).toBe(2);
     });
 
     it('should add a new object to collapsibles hash with the id from the section for blobs', function(){

--- a/spec/javascripts/collapsible_spec.js
+++ b/spec/javascripts/collapsible_spec.js
@@ -47,16 +47,14 @@ describe('Collapsible', function(){
     it('should open the collapsible when it is closed', function(){
       collapsible.close();
       expect(collapsible.isClosed()).toBe(true);
-      var event = new $.Event('click');
-      collapsible.toggle(event);
+      collapsible.toggle();
       expect(collapsible.isClosed()).toBe(false);
     });
 
     it('should close the collapsible when it is opened', function(){
       collapsible.open();
       expect(collapsible.isClosed()).toBe(false);
-      var event = new $.Event('click');
-      collapsible.toggle(event);
+      collapsible.toggle();
       expect(collapsible.isClosed()).toBe(true);
     });
   });


### PR DESCRIPTION
Some issues have been pointed out with the implementation of the accordion functionality on the following page template:
https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs

Current manuals accordion is an improvement on the previous implementation but not as accessible (to screen readers) as the implementation in the service manual e.g https://www.gov.uk/service-manual/design

Ideally we'd use the https://govuk-publishing-components.herokuapp.com/component-guide/accordion component but as this content is generated with govspeak, that isn't possible.

This PR adds fixes present in the above linked component

- Updates markup to use `button` instead of `a`
- Adds aria-expanded attribute to the button to announce state change to screenreaders
- Adds a handleClick function that contains section toggle
and button attribute toggle to announce state change to screenreaders
- Replaces open/close all anchors with more semantic html (buttons)
- Replaces section header anchors with more semantic html (buttons)
- Adds functionality that toggles section button aria attribute on open/close all - to announce state change to screenreaders
- Adds functionality that toggles open/close button's disabled attribute

This PR supersedes #642 