### PR TITLE
Revert "Update govuk_publishing_components to 17.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'plek', '2.1.1'
 
 gem 'govuk_ab_testing'
 gem 'govuk_app_config', '~> 1.18.1'
-gem 'govuk_publishing_components', '~> 17.1'
+gem 'govuk_publishing_components', '~> 16.26.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.1.0)
+    govuk_publishing_components (16.26.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -222,7 +222,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.4.1)
+    rouge (3.3.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -336,7 +336,7 @@ DEPENDENCIES
   govuk_ab_testing
   govuk_app_config (~> 1.18.1)
   govuk_frontend_toolkit (= 8.2.0)
-  govuk_publishing_components (~> 17.1)
+  govuk_publishing_components (~> 16.26.0)
   govuk_test
   jasmine
   launchy
@@ -350,4 +350,4 @@ DEPENDENCIES
   webmock (~> 3.6.0)
 
 BUNDLED WITH
-   1.17.2
+   1.16.2


### PR DESCRIPTION
Reverts alphagov/manuals-frontend#669