### PR TITLE
Add basic auth to the review app

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,14 +1,44 @@
 {
   "name": "manuals-frontend",
-  "scripts": {},
+  "repository": "https://github.com/alphagov/manuals-frontend",
   "env": {
-    "GOVUK_APP_DOMAIN": "www.gov.uk",
-    "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
-    "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api",
-    "PLEK_SERVICE_SEARCH_URI": "https://www.gov.uk/api",
-    "PLEK_SERVICE_STATIC_URI": "assets.digital.cabinet-office.gov.uk"
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_SEARCH_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_STATIC_URI": {
+      "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "RAILS_SERVE_STATIC_ASSETS": {
+      "value": "yes"
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true"
   },
-  "formation": {},
-  "addons": [],
-  "buildpacks": []
+  "image": "heroku/ruby",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": []
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,13 @@ class ApplicationController < ActionController::Base
 
   before_action :slimmer_headers
 
+  if ENV["BASIC_AUTH_USERNAME"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
+
 private
 
   def slimmer_headers


### PR DESCRIPTION
This has been lifted from [Collections](https://github.com/alphagov/collections/blob/master/app/controllers/application_controller.rb#L11-L16)
(updating app.json to be consistent with other frontend apps).

The env variables have been added to the review app already.

This is to prevent users from accidentally landing on a page in the review
app and believing that it's GOV.UK.