### PR TITLE
Update app dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ gem 'plek', '3.0.0'
 
 gem 'govuk_ab_testing'
 gem 'govuk_app_config', '~> 2.0.0'
-gem 'govuk_publishing_components', '~> 20.5.0'
+gem 'govuk_publishing_components', '~> 20.5.1'
+gem 'govuk_frontend_toolkit', '8.2.0'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,13 +100,12 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (9.0.0)
+    govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (20.5.0)
+    govuk_publishing_components (20.5.1)
       gds-api-adapters
       govuk_app_config
-      govuk_frontend_toolkit
       kramdown
       plek
       rails (>= 5.0.0.1)
@@ -337,7 +336,8 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing
   govuk_app_config (~> 2.0.0)
-  govuk_publishing_components (~> 20.5.0)
+  govuk_frontend_toolkit (= 8.2.0)
+  govuk_publishing_components (~> 20.5.1)
   govuk_test
   jasmine
   launchy


### PR DESCRIPTION
- Updates govuk_publishing_components to 20.5.1
- Brings back govuk_frontend_toolkit direct dependency as it uses javascript from it

Supersedes #721 