### PR TITLE
Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
+
   before_action :slimmer_headers
 
   if ENV["BASIC_AUTH_USERNAME"]
@@ -16,6 +18,10 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def error_403
+    render status: :forbidden, plain: "403 forbidden"
+  end
 
   def slimmer_headers
     slimmer_template "core_layout"

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -150,4 +150,13 @@ feature "Viewing manuals and sections" do
     visit "#{slug}/updates"
     expect(page.status_code).to eq(410)
   end
+
+  scenario "visiting access limited manual returns 403 forbidden" do
+    slug = "guidance/an-access-limited-manual"
+    stub_request(:get, "#{Plek.find('content-store')}/content/#{slug}").
+      to_return(status: 403, headers: {})
+
+    visit "/#{slug}/updates"
+    expect(page.status_code).to eq(403)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/1cpCsNwa/174-unauthenticated-user-accessing-a-manuals-frontend-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment manuals-frontend is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)