### PR TITLE
Allow new lines to show in change notes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -269,6 +269,7 @@ main {
     @include govuk-font(19);
     dd {
       margin-bottom: 1em;
+      white-space: pre-line;
     }
   }
 

--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -22,7 +22,7 @@
               <dt><%= link_to document.title, document.base_path %></dt>
                 <% document.change_notes.each do |note| %>
                   <dd>
-                    <%= note %>
+                    <%= note.strip %>
                   </dd>
                 <% end %>
             <% end %>

--- a/spec/features/viewing_manual_updates_spec.rb
+++ b/spec/features/viewing_manual_updates_spec.rb
@@ -36,4 +36,13 @@ feature "Viewing updates for a manual" do
                        section_title: "This is the section on hot sauce",
                        section_href: "/guidance/my-manual-about-burritos/this-is-the-section-on-hot-sauce")
   end
+
+  scenario "viewing a multi-line change note with surrounding white space" do
+    visit_manual "my-manual-about-burritos"
+    view_manual_change_notes
+
+    expect_change_note("Update fillings With a two liner",
+                       section_title: "Fillings",
+                       section_href: "/guidance/my-manual-about-burritos/fillings")
+  end
 end

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -58,6 +58,12 @@ module ManualHelpers
             published_at: "2014-06-20T09:17:27Z",
           },
           {
+            base_path: "#{base_path}/fillings",
+            title: "Fillings",
+            change_note: "   Update fillings \n With a two liner   ",
+            published_at: "2014-06-20T09:17:27Z",
+          },
+          {
             base_path: "#{base_path}/this-is-the-section-on-hot-sauce",
             title: "This is the section on hot sauce",
             change_note: "Added section on hot sauce",


### PR DESCRIPTION
Change notes (or updates) are currently rendered all on one line, which can be hard to read.

This preserves line breaks in the change notes.

Before
<img width="593" alt="Screenshot 2020-01-14 at 11 25 25" src="https://user-images.githubusercontent.com/13475227/72340788-b2d2c680-36c0-11ea-8ab8-a566ab50ebb9.png">

After
<img width="416" alt="Screenshot 2020-01-14 at 11 25 53" src="https://user-images.githubusercontent.com/13475227/72340803-b9613e00-36c0-11ea-98f7-3cc19655b70a.png">

[Trello](https://trello.com/c/rdNti5Hh/1670-5-investigate-allowing-line-breaks-in-change-notes)