### PR TITLE
Fix heading print style

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -59,12 +59,14 @@ a {
 .js-openable {
   margin-bottom: 30px;
 
-  h2 {
+  h2 button {
     font-family: "nta", Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    font-size: 16px;
+    font-size: 18px;
     line-height: 1.25;
     font-weight: bold;
+    border: none;
+    padding-left: 0;
   }
 }


### PR DESCRIPTION
Currently when users print a manual, H2s appear smaller than H3s.

This tweaks the button styles to appear larger.
[Live preview](https://manuals-fron-fix-print-m9kczh6.herokuapp.com/guidance/the-highway-code/rules-for-pedestrians-1-to-35)

**Before**
<img width="426" alt="before" src="https://user-images.githubusercontent.com/2922630/75246669-2855aa80-57c8-11ea-87ca-f2d3161731d1.png">


**After**
<img width="426" alt="after" src="https://user-images.githubusercontent.com/3758555/75247810-b6329500-57ca-11ea-87cc-a6af1a2cd53d.png">


fixes #825 