### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 AllCops:
-  TargetRubyVersion: 2.5
   Exclude:
     - 'lib/tasks/cucumber.rake' # Automatically generated
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,13 @@ AllCops:
 Layout/RescueEnsureAlignment:
   Exclude:
     - 'app/controllers/manuals_controller.rb'
+
+# The description doesn't tell us to explicitly do anything:
+# "Tagging a string as html safe may be a security risk."
+# So let's ignore it for now.
+Rails/OutputSafety:
+  Enabled: false
+
+Rails/FilePath:
+  Exclude:
+    - 'spec/rails_helper.rb' # Automatically generated

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,28 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rails', '~> 5.2.3'
-gem 'slimmer', '~> 13.2.0'
+gem "rails", "~> 5.2.3"
+gem "slimmer", "~> 13.2.0"
 
-gem 'sass-rails', '~> 5.0.6'
-gem 'uglifier', '>= 1.3.0'
+gem "sass-rails", "~> 5.0.6"
+gem "uglifier", ">= 1.3.0"
 
-gem 'gds-api-adapters', '~> 63.5'
-gem 'plek', '3.0.0'
+gem "gds-api-adapters", "~> 63.5"
+gem "plek", "3.0.0"
 
-gem 'govuk_ab_testing'
-gem 'govuk_app_config', '~> 2.0.3'
-gem 'govuk_publishing_components', '~> 21.27.1'
+gem "govuk_ab_testing"
+gem "govuk_app_config", "~> 2.0.3"
+gem "govuk_publishing_components", "~> 21.27.1"
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :development, :test do
-  gem 'jasmine'
-  gem 'pry-byebug'
+  gem "jasmine"
+  gem "pry-byebug"
   gem "rspec-rails", "~> 3.9"
-  gem 'rubocop-govuk'
+  gem "rubocop-govuk"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,10 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rubocop-govuk'
   gem 'jasmine'
   gem 'pry-byebug'
   gem "rspec-rails", "~> 3.9"
+  gem 'rubocop-govuk'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'govuk-lint'
+  gem 'rubocop-govuk'
   gem 'jasmine'
   gem 'pry-byebug'
   gem "rspec-rails", "~> 3.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,11 +89,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_ab_testing (2.4.1)
     govuk_app_config (2.0.3)
       logstasher (>= 1.2.2, < 1.4.0)
@@ -163,8 +158,8 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (3.0.0)
@@ -238,17 +233,21 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
@@ -272,8 +271,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -305,7 +302,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -331,7 +328,6 @@ DEPENDENCIES
   binding_of_caller
   gds-api-adapters (~> 63.5)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint
   govuk_ab_testing
   govuk_app_config (~> 2.0.3)
   govuk_publishing_components (~> 21.27.1)
@@ -342,6 +338,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 5.2.3)
   rspec-rails (~> 3.9)
+  rubocop-govuk
   sass-rails (~> 5.0.6)
   slimmer (~> 13.2.0)
   uglifier (>= 1.3.0)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,0 @@
-desc "Run govuk-lint with similar params to CI"
-task "lint" do
-  sh "govuk-lint-ruby --format clang Gemfile app config lib spec"
-  sh "govuk-lint-sass app/assets/stylesheets"
-end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -35,7 +35,7 @@ end
 
 namespace :publishing_api do
   desc "Publish special routes via publishing api"
-  task :publish_special_routes do
+  task publish_special_routes: :environment do
     logger = Logger.new(STDOUT)
 
     redirect_publisher = RedirectPublisher.new(logger: logger, publishing_app: "manuals-frontend")


### PR DESCRIPTION
- See commits for more details.

https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint
as part of the developer tooling group.