### PR TITLE
Use individual component sass

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,15 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
-@import 'govuk_publishing_components/all_components';
+
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/feedback';
+@import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/metadata';
+@import 'govuk_publishing_components/components/phase-banner';
+@import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/step-by-step-nav-header';
 
 // some colours used below
 $manual-search-button-border-colour: #222;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -8,4 +8,8 @@ $is-print: true;
 
 @import "manuals-print";
 
-@import "govuk_publishing_components/all_components_print";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/feedback';
+@import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/metadata';
+@import 'govuk_publishing_components/components/print/step-by-step-nav-header';


### PR DESCRIPTION
Update manuals-frontend to import the sass for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components).

## Filesize comparison

Before:

<img width="433" alt="Screenshot 2020-05-12 at 11 29 35" src="https://user-images.githubusercontent.com/861310/81696001-48a61480-945b-11ea-860b-c284695aed43.png">


Total **920 KB**

After:

<img width="435" alt="Screenshot 2020-05-12 at 14 14 19" src="https://user-images.githubusercontent.com/861310/81696094-62dff280-945b-11ea-8921-a3ca855073cc.png">

Total **398 KB**

Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

