### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,5 @@ require File.expand_path("config/application", __dir__)
 
 ManualsFrontend::Application.load_tasks
 
-task default: ["jasmine:ci"]
+Rake::Task[:default].clear unless Rails.env.production?
+task default: [:lint, :spec, "jasmine:ci"]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Linting"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end

--- a/spec/contracts/govuk_content_schemas_spec.rb
+++ b/spec/contracts/govuk_content_schemas_spec.rb
@@ -8,7 +8,7 @@ feature "Viewing manuals and sections examples from govuk-content-schemas" do
     it "should render a page including the manual title" do
       examples_for_formats(%w[manual hmrc_manual]).each do |example_json|
         content_item = JSON.parse(example_json)
-        content_store_has_item(content_item["base_path"], content_item)
+        stub_content_store_has_item(content_item["base_path"], content_item)
 
         visit content_item["base_path"]
 
@@ -23,12 +23,12 @@ feature "Viewing manuals and sections examples from govuk-content-schemas" do
       # Assumption that there is an example manual relating to every example section
       examples_for_formats(%w[manual hmrc_manual]).each do |example_json|
         content_item = JSON.parse(example_json)
-        content_store_has_item(content_item["base_path"], content_item)
+        stub_content_store_has_item(content_item["base_path"], content_item)
       end
 
       examples_for_formats(%w[manual_section hmrc_manual_section]).each do |example_json|
         content_item = JSON.parse(example_json)
-        content_store_has_item(content_item["base_path"], content_item)
+        stub_content_store_has_item(content_item["base_path"], content_item)
 
         visit content_item["base_path"]
 

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -150,7 +150,7 @@ feature "Viewing manuals and sections" do
 
   scenario "visiting a non-existent section" do
     stub_hmrc_manual
-    content_store_does_not_have_item("/hmrc-internal-manuals/inheritance-tax-manual/nonexistent-manual-section")
+    stub_content_store_does_not_have_item("/hmrc-internal-manuals/inheritance-tax-manual/nonexistent-manual-section")
 
     visit_hmrc_manual_section "inheritance-tax-manual", "nonexistent-manual-section"
     expect(page.status_code).to eq(404)

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -73,7 +73,7 @@ module ManualHelpers
       },
     }
 
-    content_store_has_item(base_path, manual_json)
+    stub_content_store_has_item(base_path, manual_json)
   end
 
   def stub_hmrc_manual(manual_id = "inheritance-tax-manual", title = "Inheritance Tax Manual")
@@ -118,7 +118,7 @@ module ManualHelpers
       },
     }
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/hmrc-internal-manuals/#{manual_id}",
       manual_json,
       max_age: 15.minutes.to_i,
@@ -164,7 +164,7 @@ module ManualHelpers
       },
     }
 
-    content_store_has_item(
+    stub_content_store_has_item(
       "/hmrc-internal-manuals/inheritance-tax-manual/eim00500",
       section_json,
       max_age: 20.minutes.to_i,
@@ -195,7 +195,7 @@ module ManualHelpers
       },
     }
 
-    content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00520", section_json)
+    stub_content_store_has_item("/hmrc-internal-manuals/inheritance-tax-manual/eim00520", section_json)
   end
 
   def stub_hmrc_manual_section_with_body(manual_id = "inheritance-tax-manual", section_id = "eim15000",
@@ -217,7 +217,7 @@ module ManualHelpers
       },
     }
 
-    content_store_has_item("/hmrc-internal-manuals/#{manual_id}/#{section_id}", section_json)
+    stub_content_store_has_item("/hmrc-internal-manuals/#{manual_id}/#{section_id}", section_json)
   end
 
   def stub_redirected_section(manual_id, section_id)
@@ -255,7 +255,7 @@ module ManualHelpers
         },
       ],
     }
-    content_store_has_item("/guidance/#{manual_id}/#{section_id}", document)
+    stub_content_store_has_item("/guidance/#{manual_id}/#{section_id}", document)
   end
 
   def stub_withdrawn_manual(base_path)
@@ -265,7 +265,7 @@ module ManualHelpers
       phase: "live",
     }
 
-    content_store_has_item(base_path, gone_json)
+    stub_content_store_has_item(base_path, gone_json)
   end
 end
 


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to
  GitHub Actions. We want one single step bundle exec rake that runs
  everything. This ensures parity between local dev and what CI runs
  (something that we don't always have now).

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

