### PR TITLE
Switch asset host to www

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,12 @@ module ManualsFrontend
 
     config.eager_load_paths << "#{config.root}/lib"
 
-    config.assets.prefix = "/manuals-frontend"
+    # Path within public/ where assets are compiled to
+    config.assets.prefix = "/assets/manuals-frontend"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,4 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
-
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,9 +54,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This allows asset host to be set by ASSET_HOST env var rather than
GOVUK_ASSET_HOST. This is in preparation for the assets of this app
changing hostname from assets.publishing.service.gov.uk to
www.gov.uk.

As part of this change the path to assets is changed to
/assets/manuals-frontend

The expectation is that this env var will only be set in dev
environments when proxying isn't set up for router.