### PR TITLE
Fix date ordering on manuals updates page

### DIFF
--- a/app/models/change_notes.rb
+++ b/app/models/change_notes.rb
@@ -18,13 +18,13 @@ private
   attr_reader :change_notes
 
   def group_updates_by_year(updates)
-    updates.group_by { |update| update.updated_at.year }.map { |year, grouped_updates|
+    updates.group_by { |update| update.updated_at.year }.sort_by { |year, _| year }.map { |year, grouped_updates|
       [year, group_updates_by_day(grouped_updates)]
     }.reverse
   end
 
   def group_updates_by_day(updates)
-    updates.group_by(&:updated_at).map { |day, grouped_updates|
+    updates.group_by(&:updated_at).sort_by { |day, _| day }.map { |day, grouped_updates|
       [day, group_updates_by_document(grouped_updates)]
     }.reverse
   end

--- a/spec/features/viewing_manual_updates_spec.rb
+++ b/spec/features/viewing_manual_updates_spec.rb
@@ -27,7 +27,7 @@ feature "Viewing updates for a manual" do
     visit_manual "my-manual-about-burritos"
     view_manual_change_notes
 
-    view_change_notes_for("20 June 2014")
+    view_change_notes_for("10 June 2016")
 
     expect_change_note(
       "Added section on fillings",

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -87,7 +87,7 @@ module AppHelpers
   end
 
   def expect_change_note(change_note, options)
-    within(".subsection-collection") do
+    within(".section-content") do
       expect(page).to have_link(options[:section_title], href: options[:section_href])
       expect(page).to have_content(change_note)
     end

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -41,7 +41,6 @@ module ManualHelpers
         title: "This is the section on hot sauce",
         change_note: "Added section on hot sauce",
         published_at: "2016-06-10T10:15:36Z",
-        # published_at: "2014-06-25T09:17:27Z",
       },
       {
         base_path: "#{base_path}/guacamole",

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -16,6 +16,42 @@ module ManualHelpers
     ).fetch("links")
   end
 
+  def example_change_notes(base_path)
+    [
+      {
+        base_path: "#{base_path}/fillings",
+        title: "Fillings",
+        change_note: "Added section on fillings",
+        published_at: "2016-06-10T10:15:36Z",
+      },
+      {
+        base_path: "#{base_path}/fillings",
+        title: "Fillings",
+        change_note: "   Update fillings \n With a two liner   ",
+        published_at: "2020-03-01T15:45:01Z",
+      },
+      {
+        base_path: "#{base_path}/salsa-options",
+        title: "Added section on salsa",
+        change_note: "Added a section on salsa",
+        published_at: "2014-06-25T09:17:27Z",
+      },
+      {
+        base_path: "#{base_path}/this-is-the-section-on-hot-sauce",
+        title: "This is the section on hot sauce",
+        change_note: "Added section on hot sauce",
+        published_at: "2016-06-10T10:15:36Z",
+        # published_at: "2014-06-25T09:17:27Z",
+      },
+      {
+        base_path: "#{base_path}/guacamole",
+        title: "This is the section on guacamole",
+        change_note: "Added section on guacamole",
+        published_at: "2020-06-20T12:30:00Z",
+      },
+    ]
+  end
+
   def stub_fake_manual(base_path: "/guidance/my-manual-about-burritos", public_updated_at: "2014-06-20T10:17:29+01:00", first_published_at: "2009-02-20T15:31:09+00:00")
     manual_json = {
       base_path: base_path,
@@ -50,26 +86,7 @@ module ManualHelpers
             title: "Cabinet Office",
           },
         ],
-        change_notes: [
-          {
-            base_path: "#{base_path}/fillings",
-            title: "Fillings",
-            change_note: "Added section on fillings",
-            published_at: "2014-06-20T09:17:27Z",
-          },
-          {
-            base_path: "#{base_path}/fillings",
-            title: "Fillings",
-            change_note: "   Update fillings \n With a two liner   ",
-            published_at: "2014-06-20T09:17:27Z",
-          },
-          {
-            base_path: "#{base_path}/this-is-the-section-on-hot-sauce",
-            title: "This is the section on hot sauce",
-            change_note: "Added section on hot sauce",
-            published_at: "2014-06-20T09:17:27Z",
-          },
-        ],
+        change_notes: example_change_notes(base_path),
       },
     }
 
@@ -114,7 +131,7 @@ module ManualHelpers
             title: "HM Revenue & Customs",
           },
         ],
-        change_notes: [],
+        change_notes: example_change_notes("/hmrc-internal-manuals/#{manual_id}"),
       },
     }
 

--- a/spec/unit/change_notes_spec.rb
+++ b/spec/unit/change_notes_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe ChangeNotes do
+  let(:content_store) { GdsApi::ContentStore.new(Plek.new.find("content-store")) }
+
+  context "for any manual" do
+    let(:content_item_change_notes) do
+      stub_fake_manual
+      content_item = content_store.content_item "/guidance/my-manual-about-burritos"
+
+      content_item["details"]["change_notes"]
+    end
+
+    it "returns change notes grouped by year and day in descending order" do
+      expected_year_groupings_order = [2020, 2016, 2014]
+      expected_date_order = [
+        Date.parse("2020-06-20"),
+        Date.parse("2020-03-01"),
+        Date.parse("2016-06-10"),
+        Date.parse("2014-06-25"),
+      ]
+
+      change_notes = ChangeNotes.new(content_item_change_notes)
+      change_note_dates = change_notes.by_year.flat_map { |_, updates| updates.map { |date, _| date } }
+
+      expect(change_notes.by_year.map { |year, _| year }).to eq(expected_year_groupings_order)
+      expect(change_note_dates).to eq(expected_date_order)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes date ordering on the manuals updates page. Previously, HMRC manuals displayed updates from earliest to most recent, whereas other manuals displayed updates from most recent to the earliest.

The reason for this is because the change notes for HMRC manuals, as recorded in the content item, ranged from most recent to earliest, whereas for other manuals was from earliest to most recent. A `reverse` operation was then applied to these change notes in the code, which meant that HMRC manuals were then displayed in the wrong order.

To resolve this, instead sort by date descending to ensure ordering is consistent for different manuals.

Raised from [this Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4181394).