### PR TITLE
Replace accordion content hiding solution with display: none

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -414,11 +414,7 @@ main {
       }
 
       .js-subsection-body {
-        position: absolute;
-        left: -9999px;
-        width: 100px;
-        height: 1px;
-        overflow: hidden;
+        display: none;
       }
     }
   }


### PR DESCRIPTION
## What
Replace the CSS for hiding accordion content with `display: none`

## Why
Currently, screen reader users and keyboard only users have to go through all the content of each accordion, meaning it's not possible to skim each accordion and only open the ones that the user actually wants to read. This fails WCAG SC 4.1.2 (buttons) and 3.2.1 or 1.3.2 (keyboard). This change ensures that content is hidden when collapsed and shown when not, which screen readers recognise when navigating the page.

**Card:** https://trello.com/c/R5qH7sOM/331-manuals-accordion-not-working-for-screen-reader-and-keyboard-only-users