### PR TITLE
Move phase banner and contextual breadcrumbs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
   <div id="wrapper">
+    <% if @presented_manual.beta? %>
+      <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
+    <% end %>
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_store_manual %>
     <main role="main" class="hmrc-internal-manuals-frontend-content outer-block">
       <div id="manuals-frontend" class='manuals-frontend-body inner-block'>
         <%= yield %>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -1,9 +1,3 @@
-<% if presented_manual.beta? %>
-  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
-<% end %>
-
-<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_store_manual %>
-
 <header aria-labelledby="manual-title" class="<%= presented_manual.hmrc? ? 'hmrc' : nil %> govuk-grid-row">
   <div class='govuk-grid-column-two-thirds'>
     <% if presented_manual.hmrc? %>


### PR DESCRIPTION
## What
Moved phase banner and contextual breadcrumbs outside of main in manuals
frontend. 

## Why
`<main>` should only contain elements that are unique to the
document, which the breadcrumbs and phase banner are not.

## Visual changes
This should not result in any visual changes


https://trello.com/c/UbK2Cher