### PR TITLE
Fix HMRC manuals header WCAG fail

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,7 +44,7 @@ main {
     background: $govuk-brand-colour;
 
     &.hmrc {
-      background: govuk-organisation-colour("hm-revenue-customs", $websafe: false);
+      background: govuk-organisation-colour("hm-revenue-customs");
     }
 
     padding-top: govuk-spacing(6);


### PR DESCRIPTION
## Problem

On HMRC manual pages such as [this one](https://www.gov.uk/hmrc-internal-manuals/paye-manual/paye70201), the turquoise background and white text of the content header don't meet the minimum contrast requirements for regular sized text.

The adjacent colours against the search button when it is focused don't meet the minimum colour contrast requirements.

This fails WCAG SC 1.4.3 (content header) and 1.4.11 (search button).

## Solution
Use websafe version of the HMRC brand colour, which is conducive to better contrast, to ensure the header text is readable.

### Before (top) vs after (bottom)
<img width="924" alt="Screenshot 2020-10-09 at 18 00 54" src="https://user-images.githubusercontent.com/7116819/95611252-79fe2d00-0a59-11eb-870a-2ed676815e03.png">
