### PR TITLE
Update govspeak component usage

### DIFF
--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -2,7 +2,9 @@
   <div class='manual-body'>
     <% if presented_manual.summary.present? %><p class='summary'><%= presented_manual.summary %></p><% end %>
     <% if presented_manual.body.present? %>
-      <%= render 'govuk_publishing_components/components/govspeak', content: presented_manual.body %>
+      <%= render "govuk_publishing_components/components/govspeak", {} do %>
+        <%= sanitize(presented_manual.body) %>
+      <% end %>
     <% end %>
     <% presented_manual.section_groups.each do | group | %>
       <% if presented_manual.hmrc? %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -5,8 +5,9 @@
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
         <div class='body-content-wrapper'>
-          <%= render 'govuk_publishing_components/components/govspeak',
-            content: presented_document.body %>
+          <%= render "govuk_publishing_components/components/govspeak", {} do %>
+            <%= sanitize(presented_document.body) %>
+          <% end %>
         </div>
       <% end %>
       <div class='subsection-collection'>
@@ -21,7 +22,9 @@
       <% if presented_document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= presented_document.collapse_depth %>>
           <div class='collapsible-subsections'>
-            <%= render 'govuk_publishing_components/components/govspeak', content: presented_document.body %>
+            <%= render "govuk_publishing_components/components/govspeak", {} do %>
+              <%= sanitize(presented_document.body) %>
+            <% end %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
### What
Updates the way the Govspeak component to not use the content parameter.

### Why
The Govspeak component should not be used with the content parameter as that will be deprecated; it should use a do block wrapped around sanitized markup instead.

See alphagov/govuk_publishing_components#1632 for more info.

### Visual differences
None.