### PR TITLE
Revert calls to govspeak component

### DIFF
--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -2,9 +2,7 @@
   <div class='manual-body'>
     <% if presented_manual.summary.present? %><p class='summary'><%= presented_manual.summary %></p><% end %>
     <% if presented_manual.body.present? %>
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= sanitize(presented_manual.body) %>
-      <% end %>
+      <%= render 'govuk_publishing_components/components/govspeak', content: presented_manual.body %>
     <% end %>
     <% presented_manual.section_groups.each do | group | %>
       <% if presented_manual.hmrc? %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -5,9 +5,8 @@
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
         <div class='body-content-wrapper'>
-          <%= render "govuk_publishing_components/components/govspeak", {} do %>
-            <%= sanitize(presented_document.body) %>
-          <% end %>
+          <%= render 'govuk_publishing_components/components/govspeak',
+            content: presented_document.body %>
         </div>
       <% end %>
       <div class='subsection-collection'>
@@ -22,9 +21,7 @@
       <% if presented_document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= presented_document.collapse_depth %>>
           <div class='collapsible-subsections'>
-            <%= render "govuk_publishing_components/components/govspeak", {} do %>
-              <%= sanitize(presented_document.body) %>
-            <% end %>
+            <%= render 'govuk_publishing_components/components/govspeak', content: presented_document.body %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
This reverts https://github.com/alphagov/manuals-frontend/pull/995 as the added sanitize call is causing table markup to fail. Initially overlooked as checked pages didn't contain tables. Will look at safer implementation after reverting.