### PR TITLE
Update govspeak component implementation

### DIFF
--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -2,7 +2,9 @@
   <div class='manual-body'>
     <% if presented_manual.summary.present? %><p class='summary'><%= presented_manual.summary %></p><% end %>
     <% if presented_manual.body.present? %>
-      <%= render 'govuk_publishing_components/components/govspeak', content: presented_manual.body %>
+      <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+        <%= raw(presented_manual.body) %>
+      <% end %>
     <% end %>
     <% presented_manual.section_groups.each do | group | %>
       <% if presented_manual.hmrc? %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -5,6 +5,9 @@
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
         <div class='body-content-wrapper'>
+          <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+            <%= raw(presented_document.body) %>
+          <% end %>
           <%= render 'govuk_publishing_components/components/govspeak',
             content: presented_document.body %>
         </div>
@@ -21,7 +24,9 @@
       <% if presented_document.body.present? %>
         <div class='js-collapsible-collection subsection-collection' data-collapse-depth=<%= presented_document.collapse_depth %>>
           <div class='collapsible-subsections'>
-            <%= render 'govuk_publishing_components/components/govspeak', content: presented_document.body %>
+            <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+              <%= raw(presented_document.body) %>
+            <% end %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
This is a reimplementation of https://github.com/alphagov/manuals-frontend/pull/995

It updates the way that the govspeak component is called as the content parameter will be deprecated. It should use a do block ideally wrapped around sanitized markup. In the previous PR we sanitized the input but this failed embarrassingly in production and had to be reverted.

I investigated a more permissive sanitize attempt with exceptions, but while some pages, such as https://www.gov.uk/hmrc-internal-manuals/child-benefit-technical-manual/cbtm02120 would benefit from this approach if we allowed table syntax, other pages are more complex. To get https://www.gov.uk/guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/3-visibility to render properly I had to specify acceptance of h2, h3, id, button, ol, li, span, div, table, th, tr, td, p, br, scope, class. Without being able to determine an exhaustive list of acceptable tags and attributes I reverted to wrapping the input in raw() when passing it to the component.