### PR TITLE
Add PR template before enabling automatic deploys

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+:warning: This application is Continuously Deployed: :warning:
+
+- Merged changes are automatically deployed to staging and production.
+
+- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
+
+- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/manuals-frontend), after merging.


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

This is part of enabling automatic deployments for this app.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/manuals-frontend), after merging.