### PR TITLE
Fix duplicated body text in manual section

### DIFF
--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -8,8 +8,6 @@
           <%= render 'govuk_publishing_components/components/govspeak', {} do %>
             <%= raw(presented_document.body) %>
           <% end %>
-          <%= render 'govuk_publishing_components/components/govspeak',
-            content: presented_document.body %>
         </div>
       <% end %>
       <div class='subsection-collection'>


### PR DESCRIPTION
Removing a extra render of the body text in the manual section.