### PR TITLE
[WIP] Testing manual information callouts

### DIFF
--- a/app/views/manuals/_hmrc_callout.html.erb
+++ b/app/views/manuals/_hmrc_callout.html.erb
@@ -1,0 +1,7 @@
+<% if presented_manual.hmrc? %>
+  <%= render "govuk_publishing_components/components/govspeak", {} do %>
+    <div role="note" aria-label="Information" class="application-notice info-notice">
+      <p>There is something afoot</p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -1,6 +1,9 @@
 <article aria-labelledby="manual-title" id="content">
   <div class='manual-body'>
     <% if presented_manual.summary.present? %><p class='summary'><%= presented_manual.summary %></p><% end %>
+
+    <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
+
     <% if presented_manual.body.present? %>
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
         <%= raw(presented_manual.body) %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -2,6 +2,9 @@
   <article aria-labelledby="section-title">
     <h1 id="section-title" class='section-title'><%= presented_document.title %></h1>
     <% if presented_document.summary %><p class='summary'><%= presented_document.summary %></p><% end %>
+
+    <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
+
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
         <div class='body-content-wrapper'>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -39,12 +39,14 @@ feature "Viewing manuals and sections" do
   scenario "viewing a non-HMRC manual" do
     stub_fake_manual
     visit_manual "my-manual-about-burritos"
+    expect(page).not_to have_text("There is something afoot")
     expect(page).not_to have_selector(".gem-c-phase-banner")
   end
 
   scenario "viewing an HMRC manual" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
+    expect(page).to have_css(".gem-c-govspeak", text: "There is something afoot")
     expect(page).to have_selector(".gem-c-phase-banner")
   end
 


### PR DESCRIPTION
The markup for the callout was taken from the [component guide](https://components.publishing.service.gov.uk/component-guide/govspeak/information_callout) example.

This callout will appear on HMRC content only.

- https://manuals-fron-callout-tygsdqluy.herokuapp.com/hmrc-internal-manuals/international-manual  
- https://manuals-fron-callout-tygsdqluy.herokuapp.com/hmrc-internal-manuals/international-manual/intm120000
- https://manuals-fron-callout-tygsdqluy.herokuapp.com/hmrc-internal-manuals/international-manual/intm120010

https://trello.com/c/yR4zJzdA/717-spike-hmrc-manuals-callout

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
