### PR TITLE
Replace bespoke code with components

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -4,7 +4,7 @@ a {
 
 // hide all the unnecessary things
 .alpha-label,
-.breadcrumb-trail,
+.js-title-controls-wrap,
 .print-page,
 .secondary .feedback,
 .in-manual-search {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -88,58 +88,6 @@ main {
     }
   }
 
-  .breadcrumb-trail {
-    @include govuk-font(16);
-    margin: govuk-spacing(2) 0 0 0;
-    padding: 0 0 govuk-spacing(2);
-    border-bottom: 1px solid $govuk-border-colour;
-
-    strong {
-      @include govuk-typography-weight-bold;
-    }
-
-    li {
-      background-image: image-url("separator.png");
-      background-position: 100% 20%;
-      background-repeat: no-repeat;
-      display: inline;
-      list-style: none;
-      margin-left: 0;
-      margin-right: govuk-spacing(1);
-      padding: 0 govuk-spacing(3) 0 0;
-
-      @include govuk-media-query($from: tablet) {
-        background-position: 100% 45%;
-      }
-
-      @include govuk-device-pixel-ratio {
-        background-image: image-url("separator-2x.png");
-        background-size: 6px 11px;
-      }
-
-      &:first-child {
-        margin-left: 0;
-      }
-
-      &.last-child {
-        background-image: none;
-        color: $govuk-text-colour;
-      }
-
-      &.no-separator {
-        background-image: none;
-      }
-
-      a {
-        color: $govuk-text-colour;
-
-        &:focus {
-          @include govuk-focused-text;
-        }
-      }
-    }
-  }
-
   .section-list {
     margin-top: govuk-spacing(6);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/metadata';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 
 // stylelint-disable selector-no-qualifying-type, max-nesting-depth -- This
@@ -83,62 +84,6 @@ main {
 
       &:focus {
         @include govuk-focused-text;
-      }
-    }
-
-    .in-manual-search {
-      position: relative;
-      margin: govuk-spacing(6) 0 govuk-spacing(3);
-
-      label {
-        padding-bottom: govuk-spacing(1);
-        display: inline-block;
-      }
-
-      .in-manual-search-box {
-        width: 86%;
-        width: calc(100% - 47px);
-        border: none;
-        padding: 9px 7px;
-        height: 16px;
-
-        &.focus,
-        &:focus {
-          position: relative;
-          z-index: 1;
-          outline-color: $govuk-focus-colour;
-          box-shadow: inset 0 0 0 3px govuk-colour("black");
-        }
-
-        @include govuk-media-query($from: tablet) {
-          padding: 7px;
-          height: 20px;
-        }
-      }
-
-      button {
-        width: 34px;
-        height: 34px;
-        border: 1px solid govuk-colour("black");
-        border-width: 0 0 0 1px;
-        border-left-color: $manual-search-button-border-colour;
-        overflow: hidden;
-        text-indent: -5000px;
-        cursor: pointer;
-        color: govuk-colour("white");
-        background: govuk-colour("black") image-url("search-button.png") no-repeat 0 50%;
-        position: absolute;
-
-        border-radius: 0;
-
-        @include govuk-device-pixel-ratio {
-          background-size: 52.5px 35px;
-          background-position: 100% 50%;
-        }
-
-        &:focus {
-          outline-color: $govuk-focus-colour;
-        }
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/heading';
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -9,10 +9,13 @@
 
     <div class="in-manual-search">
       <form action="/search/all" >
-        <label for="search-box">Search this manual</label>
+
         <input type='hidden' name="manual[]" value="<%= presented_manual.url %>">
-        <input id="search-box" class="in-manual-search-box" type="text" name="q"/>
-        <button type="submit">search</button>
+
+        <%= render "govuk_publishing_components/components/search", {
+          on_govuk_blue: true,
+          label_text: "Search this manual",
+        } %>
       </form>
     </div>
   </div>

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -4,7 +4,7 @@
       <span class='manual-type'>HMRC internal manual</span>
     <% end %>
 
-    <h1 id="manual-title"><%= presented_manual.title %></h1>
+    <%= yield :guide_heading %>
     <%= render 'govuk_publishing_components/components/metadata', presented_manual.metadata %>
 
     <div class="in-manual-search">

--- a/app/views/manuals/_header.html.erb
+++ b/app/views/manuals/_header.html.erb
@@ -16,11 +16,4 @@
       </form>
     </div>
   </div>
-  <div class='govuk-grid-column-one-third'>
-    <div class='secondary-inner'>
-      <p>
-        <%= link_to 'Give feedback about this page', 'https://www.gov.uk/contact/govuk', :class=> "feedback" %>
-      </p>
-    </div>
-  </div>
 </header>

--- a/app/views/manuals/_manual_breadcrumbs.html.erb
+++ b/app/views/manuals/_manual_breadcrumbs.html.erb
@@ -1,14 +1,29 @@
-<ol class='breadcrumb-trail'>
-  <% if request.path == presented_manual.url %>
-    <li class="no-separator">Contents</li>
-  <% else %>
-    <li><%= link_to 'Contents', presented_manual.url %></li>
-  <% end %>
+<%=
+  crumbs = []
 
-  <% if local_assigns.has_key?(:presented_document) %>
-    <% presented_document.breadcrumbs.each do | crumb | %>
-      <li> <%= link_to crumb.label, crumb.link %></li>
-    <% end %>
-    <li class='last-child'><%= presented_document.breadcrumb %></li>
-  <% end %>
-</ol>
+  if request.path == presented_manual.url
+    crumbs.push({
+      title: "Contents",
+    })
+  else
+    crumbs.push({
+      title: "Contents",
+      url: presented_manual.url,
+    })
+  end
+
+  if local_assigns.has_key?(:presented_document)
+    presented_document.breadcrumbs.each do | crumb |
+      crumbs.push({
+        title: crumb.label,
+        url: crumb.link,
+      })
+    end
+  end
+
+  render "govuk_publishing_components/components/breadcrumbs", {
+    border: "bottom",
+    breadcrumbs: crumbs,
+    collapse_on_mobile: false,
+  }
+%>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -1,6 +1,12 @@
 <div class='manual-body' id="content">
   <article aria-labelledby="section-title">
-    <h1 id="section-title" class='section-title'><%= presented_document.title %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: presented_document.title,
+      font_size: "m",
+      id: "section-title",
+      heading_level: 1,
+      margin_bottom: 4,
+    } %>
     <% if presented_document.summary %><p class='summary'><%= presented_document.summary %></p><% end %>
 
     <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -1,7 +1,12 @@
-<div class='manual-body' id="content">
+<%
+  document_heading = []
+  document_heading << "#{presented_document.breadcrumb} - " if presented_document.breadcrumb.present?
+  document_heading << presented_document.title
+
+%><div class='manual-body' id="content">
   <article aria-labelledby="section-title">
     <%= render "govuk_publishing_components/components/heading", {
-      text: presented_document.title,
+      text: document_heading.join,
       font_size: "m",
       id: "section-title",
       heading_level: 1,

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -12,7 +12,9 @@
       heading_level: 1,
       margin_bottom: 4,
     } %>
-    <% if presented_document.summary %><p class='summary'><%= presented_document.summary %></p><% end %>
+    <% if presented_document.summary.present? %>
+      <p class="summary"><%= presented_document.summary %></p>
+    <% end %>
 
     <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
 

--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -4,6 +4,7 @@
       font_size: "l",
       heading_level: 1,
       id: "section-title",
+      margin_bottom: 4,
       text: "Updates: #{presented_manual.title}",
     } %>
     <% presented_manual.change_notes.by_year.each do |year, updates_by_year| %>

--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -1,12 +1,11 @@
 <div class='manual-body' id="content">
   <article aria-labelledby="section-title">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Updates: #{presented_manual.title}",
       font_size: "l",
       heading_level: 1,
       id: "section-title",
+      text: "Updates: #{presented_manual.title}",
     } %>
-
     <% presented_manual.change_notes.by_year.each do |year, updates_by_year| %>
       <%= render "govuk_publishing_components/components/heading", {
         text: year,

--- a/app/views/manuals/index.html.erb
+++ b/app/views/manuals/index.html.erb
@@ -1,3 +1,12 @@
+<% content_for :guide_heading do %>
+  <%= render "govuk_publishing_components/components/heading", {
+      text: presented_manual.title,
+      font_size: "l",
+      inverse: true,
+      id: "manual-title",
+      heading_level: 1,
+  } %>
+<% end %>
 <%=
   render(
     'content_for_head_tag',

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -1,3 +1,13 @@
+<% content_for :guide_heading do %>
+  <%= render "govuk_publishing_components/components/heading", {
+      text: presented_manual.title,
+      font_size: "l",
+      inverse: true,
+      id: "manual-title",
+      heading_level: 1,
+      margin_bottom: 6,
+  } %>
+<% end %>
 <%=
   render(
     'content_for_head_tag',

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -1,3 +1,13 @@
+<% content_for :guide_heading do %>
+  <%= render "govuk_publishing_components/components/heading", {
+      text: presented_manual.title,
+      font_size: "l",
+      inverse: true,
+      id: "manual-title",
+      heading_level: 2,
+      margin_bottom: 6,
+  } %>
+<% end %>
 <%=
   render(
     'content_for_head_tag',

--- a/spec/support/app_helpers.rb
+++ b/spec/support/app_helpers.rb
@@ -67,7 +67,7 @@ module AppHelpers
   def expect_section_title_to_be(section_title)
     raise ArgumentError, "You probably didn't mean to check for a blank section title" if section_title.blank?
 
-    within("h1.section-title") do
+    within("article h1") do
       expect(page).to have_content(section_title)
     end
   end


### PR DESCRIPTION
The following items have been updated:

- H1 headings now use the heading component. The issue of having 2 H1s is recognised but not being tackled at this point.
- Search box now uses the search component
- Breadcrumbs now use breadcrumbs component: ~NOTE: **BLOCKED** AWAITING APPROVAL FROM HMRC - We may need to extend the component to accommodate the current page final crumb.~ Approval to move the final crumb to the start of the heading has been given.
- The feedback link has been removed as it duplicates functionality as the feedback component is at the bottom of the page.

Linked Trello: https://trello.com/c/1ooPxPEP/563-update-manuals-frontend-to-use-components

### Before
![Screenshot 2021-02-04 at 12 06 07](https://user-images.githubusercontent.com/31649453/106890623-82056b00-66e1-11eb-95d4-4a6ca279c468.png)

### After
![image](https://user-images.githubusercontent.com/1732331/109664258-dbd44600-7b64-11eb-87a7-dc46d88e673b.png)


Sample pages:
 * https://www.gov.uk/guidance/content-design - ([dev.gov.uk](http://manuals-frontend.dev.gov.uk/guidance/content-design))
 * https://www.gov.uk/guidance/content-design/what-is-content-design - ([dev.gov.uk](http://manuals-frontend.dev.gov.uk/guidance/content-design/what-is-content-design))
 * https://www.gov.uk/guidance/content-design/updates - ([dev.gov.uk](http://manuals-frontend.dev.gov.uk/guidance/content-design/updates))
 * https://www.gov.uk/hmrc-internal-manuals/compliance-handbook/ch20150 - ([dev.gov.uk](http://manuals-frontend.dev.gov.uk/hmrc-internal-manuals/compliance-handbook/ch20150))

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
