### PR TITLE
Delete current_location.js

### DIFF
--- a/app/assets/javascripts/modules/current_location.js
+++ b/app/assets/javascripts/modules/current_location.js
@@ -1,8 +1,0 @@
-(function () {
-  'use strict'
-  window.GOVUK = window.GOVUK || {}
-
-  window.GOVUK.getCurrentLocation = function () {
-    return window.location
-  }
-}())


### PR DESCRIPTION
## What
Delete current-location.js

## Why
Already [available via GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/lib/current-location.js)

## Visual Changes
n/a

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
