### PR TITLE
Improve print view of manual updates list

### DIFF
--- a/app/assets/stylesheets/_manuals-print.scss
+++ b/app/assets/stylesheets/_manuals-print.scss
@@ -17,30 +17,6 @@ a {
     padding: 0 0 10px;
     font-weight: bold;
   }
-
-  dl {
-    float: left;
-    margin-top: 0;
-    width: 100%;
-
-    dt {
-      min-width: 100px;
-      float: left;
-
-      &:after {
-        content: ":";
-      }
-    }
-
-    dd {
-      font-weight: bold;
-      margin-left: 0;
-    }
-
-    dd a:after {
-      content: "";
-    }
-  }
 }
 
 .manual-body {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -276,11 +276,6 @@ main {
 
   .updates-list {
     @include govuk-font(19);
-
-    dd {
-      margin-bottom: 1em;
-      white-space: pre-line;
-    }
   }
 
   .collapsible-subsections {

--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -17,14 +17,15 @@
         heading_level: 3,
         items: updates_by_year.map do |day, updated_documents|
           accordion_content = capture do %>
-            <dl class='updates-list'>
+            <div class='updates-list'>
               <% updated_documents.each do |document| %>
-                <dt><%= link_to document.title, document.base_path, class: "govuk-link" %></dt>
-                  <% document.change_notes.each do |note| %>
-                    <dd><%= note.strip %></dd>
-                  <% end %>
+                <p><%= link_to document.title, document.base_path, class: "govuk-link" %></p>
+                <% document.change_notes.each do |note| %>
+                  <p><%= note.strip %></p>
+                <% end %>
+                <br/>
               <% end %>
-            </dl>
+            </div>
           <% end
 
           {


### PR DESCRIPTION
This adds a `<br>` and uses `<p>` so the updates list is easier to read when printed as a PDF.

To review:

1. compare the following page on the live site with that on the review app:
   - live: https://www.gov.uk/guidance/test-family-procedures-rules/updates
   - review: https://manuals-fron-bilbof-imp-inj3ce.herokuapp.com/guidance/test-family-procedures-rules/updates
2. Click "Print this page" at the bottom to view the PDF

Ticket: https://govuk.zendesk.com/agent/tickets/4461812

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
