### PR TITLE
Render newlines in manual update notes

### DIFF
--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -21,7 +21,7 @@
               <% updated_documents.each do |document| %>
                 <p><%= link_to document.title, document.base_path, class: "govuk-link" %></p>
                 <% document.change_notes.each do |note| %>
-                  <p><%= note.strip %></p>
+                  <%= simple_format(note) %>
                 <% end %>
                 <br/>
               <% end %>


### PR DESCRIPTION
Change notes (what we render on /guidance/`<manual>`/updates) can have newline characters. We were stripping them, which makes it hard to read (and worse when printing the page).

Using [simple_format](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-simple_format) renders the newlines instead, making the page easier to read.

simple_format also sanitizes the change notes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
