### PR TITLE
Add anchor navigation feature flag to accordions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -73,6 +73,7 @@ class Document
       {
         heading: {
           text: heading.text,
+          id: heading[:id],
         },
         content: content.join,
       }

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -28,6 +28,7 @@
         end %>
 
         <%= render "govuk_publishing_components/components/accordion", {
+          anchor_navigation: true,
           items: presented_document.main.map do |item|
             rendered_content = render "govuk_publishing_components/components/govspeak", {} do
               raw(item[:content])


### PR DESCRIPTION
## What
Adds an id attribute to the `heading` object on accordion rendering, as well as the `anchor_navigation` feature flag to allow anchor navigation on manuals page accordions.

## Why
Part of a fix of the previous feature allowing manuals to link to individual accordion sections on other manuals.

requires [this PR on the components gem](https://github.com/alphagov/govuk_publishing_components/pull/1937) to be released before his can be merged and deployed.

No visual changes.