### PR TITLE
Return 406 Not Acceptable when 'Accepts' header requests non-HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from GdsApi::HTTPForbidden, with: :error_403
+  rescue_from ActionView::MissingTemplate, with: :error_406
+  rescue_from ActionController::UnknownFormat, with: :error_406
 
   before_action :slimmer_headers
 
@@ -21,6 +23,10 @@ private
 
   def error_403
     render status: :forbidden, plain: "403 forbidden"
+  end
+
+  def error_406
+    render plain: "Not acceptable", status: :not_acceptable
   end
 
   def slimmer_headers

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure(&:infer_spec_type_from_file_location!)
 
 RSpec.configure do |c|
   c.example_status_persistence_file_path = "spec/failures"
+  c.include Capybara::RSpecMatchers, type: :request
 end
 
 GovukAbTesting.configure do |config|

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Manuals" do
+  describe "GET ManualsController#index" do
+    it "returns successfully" do
+      slug = "/guidance/my-manual-about-burritos"
+      stub_fake_manual(base_path: slug)
+      get slug
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET ManualsController#index with unacceptable 'Accept' header" do
+    it "returns 406 Not Acceptable" do
+      slug = "/guidance/my-manual-about-burritos"
+      stub_fake_manual(base_path: slug)
+      get slug, params: {}, headers: { "Accept" => "application/json" }
+
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  describe "GET ManualsController#show" do
+    it "returns successfully" do
+      slug = "/guidance/my-manual-about-burritos"
+      stub_fake_manual(base_path: slug)
+      section = "/guidance/my-manual-about-burritos/section"
+      stub_fake_manual(base_path: section)
+      get section
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET ManualsController#show with unacceptable 'Accept' header" do
+    it "returns 406 Not Acceptable" do
+      slug = "/guidance/my-manual-about-burritos"
+      stub_fake_manual(base_path: slug)
+      section = "/guidance/my-manual-about-burritos/section"
+      stub_fake_manual(base_path: section)
+      get section, params: {}, headers: { "Accept" => "application/json" }
+
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+end


### PR DESCRIPTION
We've had a number of Sentry issues to do with requesting JSON or
JS versions of Manuals Frontend pages:
- https://sentry.io/organizations/govuk/issues/2152998596/?project=202235&query=is%3Aunresolved
- https://sentry.io/organizations/govuk/issues/2161602206/?project=202235&query=is%3Aunresolved

The correct thing to do is to respond with a [406](https://httpstatuses.com/406),
and not to log inactionable Sentry issues.

I've taken inspiration from Content Publisher for the request
testing, and the underlying fix is the same approach as in
government-frontend:
https://github.com/alphagov/government-frontend/blob/ce26ae94d66d9ce92ac37028854211741ef44b8b/app/controllers/content_items_controller.rb#L6-L7

We will also need to do some work to ensure that 406 responses
are cached in Fastly.

Trello: https://trello.com/c/XNQhMGRt/2391-3-make-manuals-frontend-respond-to-bad-requests-with-406-status

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
