### PR TITLE
ManualSections that are"visually_expanded" render without accordions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,6 +39,10 @@ class Document
     details["body"] && details["body"].html_safe
   end
 
+  def visually_expanded?
+    details.fetch("visually_expanded", false)
+  end
+
   def intro
     return nil unless body
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -19,10 +19,6 @@ class Section
     section["base_path"]
   end
 
-  def collapsible?
-    body.present?
-  end
-
   def summary
     section["description"]
   end

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -51,7 +51,23 @@
           <%= render "govuk_publishing_components/components/govspeak", {} do
             raw(presented_document.intro)
           end %>
-
+        <% if presented_document.visually_expanded? %>
+          <% presented_document.main.map do |item| %>
+            <div class="subsection__header govuk-!-margin-bottom-3">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: item[:heading][:text],
+                font_size: "m",
+                margin_bottom: 1,
+                id: item[:heading][:id],
+              } %>
+            </div>
+            <div class="govuk-body govuk-!-margin-bottom-1 subsection__description">
+              <%= render "govuk_publishing_components/components/govspeak", {} do
+                raw(item[:content])
+              end %>
+            </div>
+          <% end %>
+        <% else %>
           <%= render "govuk_publishing_components/components/accordion", {
             anchor_navigation: true,
             items: presented_document.main.map do |item|
@@ -67,6 +83,7 @@
               }
             end
           } %>
+        <% end %>
         </div>
       <% end %>
     <% end %>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -127,6 +127,23 @@ feature "Viewing manuals and sections" do
     expect(page).to have_content("Sections 386-400 ITEPA 2003")
   end
 
+  scenario "visiting a visually collapsed manual section", js: true do
+    stub_fake_manual
+    stub_fake_manual_sections
+
+    visit_manual_section "my-manual-about-burritos", "collapsed-section"
+
+    expect(page).to have_css(".gem-c-accordion", text: "Show all sections")
+  end
+
+  scenario "visiting a visually expanded manual section", js: true do
+    stub_fake_manual
+    stub_fake_manual_sections
+
+    visit_manual_section "my-manual-about-burritos", "expanded-section"
+    expect(page).not_to have_css(".gem-c-accordion", text: "Show all sections")
+  end
+
   scenario "HMRC manual section IDs are displayed in the title" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -92,6 +92,55 @@ module ManualHelpers
     stub_content_store_has_item(base_path, manual_json)
   end
 
+  def stub_fake_manual_sections(base_path: "/guidance/my-manual-about-burritos", public_updated_at: "2014-06-20T10:17:29+01:00", first_published_at: "2009-02-20T15:31:09+00:00")
+    collapsed_manual_section_json = {
+      base_path: "#{base_path}/collapsed-section",
+      title: "Fillings",
+      description: "This section details the fillings",
+      format: "manual_section",
+      first_published_at: first_published_at,
+      public_updated_at: public_updated_at,
+      links: example_links,
+      details: {
+        body: "<h2>Heading</h2><p>body and <a href=\"https://example.com\">link</a>.</p>",
+        organisations: [
+          {
+            abbreviation: "CO",
+            web_url: "http://www.gov.uk/government/organisations/cabinet-office",
+            title: "Cabinet Office",
+          },
+        ],
+        change_notes: example_change_notes(base_path),
+        visually_expanded: false,
+      },
+    }
+
+    expanded_manual_section_json = {
+      base_path: "#{base_path}/expanded-section",
+      title: "This is the section on hot sauce",
+      description: "Hot sauces are good",
+      format: "manual_section",
+      first_published_at: first_published_at,
+      public_updated_at: public_updated_at,
+      links: example_links,
+      details: {
+        body: "<h2>Heading</h2><p>body and <a href=\"https://example.com\">link</a>.</p>",
+        organisations: [
+          {
+            abbreviation: "CO",
+            web_url: "http://www.gov.uk/government/organisations/cabinet-office",
+            title: "Cabinet Office",
+          },
+        ],
+        change_notes: example_change_notes(base_path),
+        visually_expanded: true,
+      },
+    }
+
+    stub_content_store_has_item("#{base_path}/collapsed-section", collapsed_manual_section_json)
+    stub_content_store_has_item("#{base_path}/expanded-section", expanded_manual_section_json)
+  end
+
   def stub_hmrc_manual(manual_id = "inheritance-tax-manual", title = "Inheritance Tax Manual")
     manual_json = {
       base_path: "/hmrc-internal-manuals/#{manual_id}",


### PR DESCRIPTION
Manual sections that are published as `"visually_expanded": true`
will render as flat text  without the "accordion" govuk_publishing_component.
https://components.publishing.service.gov.uk/component-guide/accordion

The default publishing option is `"visually_expanded": false`. If the
`visually_expanded` attribute is not set the section will also continue
to display as an accordion.

Also removes an unused `collapsible?` method from the Section model.

#### Default `"visually_expanded": false` or absent
<img width="1015" alt="Screenshot 2021-03-09 at 10 53 08" src="https://user-images.githubusercontent.com/13475227/110460333-f27b1f80-80c5-11eb-8ca8-f4667ce8a426.png">

------

#### Specified `"visually_expanded": true`
<img width="966" alt="Screenshot 2021-03-09 at 10 54 43" src="https://user-images.githubusercontent.com/13475227/110460346-f7d86a00-80c5-11eb-802f-7953be44e8c2.png">


[govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/1051)
[trello](https://trello.com/c/wgEKW9Ze/2398-5-allow-manuals-publisher-to-set-accordions-to-open)
