### PR TITLE
Prevent manual_section title from appearing twice

### DIFF
--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -1,12 +1,12 @@
 <%
   document_heading = []
-  document_heading << "#{presented_document.breadcrumb} - " if presented_document.breadcrumb.present?
-  document_heading << presented_document.title
+  document_heading << presented_document.breadcrumb if presented_document.breadcrumb.present?
+  document_heading << presented_document.title unless document_heading.include?(presented_document.title)
 
 %><div class='manual-body' id="content">
   <article aria-labelledby="section-title">
     <%= render "govuk_publishing_components/components/heading", {
-      text: document_heading.join,
+      text: document_heading.join(" - "),
       font_size: "m",
       id: "section-title",
       heading_level: 1,


### PR DESCRIPTION
A change to add the breadcrumb to the document heading for
manual_section view has caused the title to sometimes appear twice.

The document_heading is intended to present the `section_id - title`.
The intention is that the `breadcrumb` method should provide the `section_id` - however
if this is not present it nstead defaults to `title`.

https://github.com/alphagov/manuals-frontend/blob/63c17fff271e85fcf9f6196963e0d4135214c29f/app/models/document.rb#L26

This change prevents the title being added to the document_heading if it
is already present i.e: the `breadcrumb` method was unable to return a `section_id`.