### PR TITLE
Apply two thirds width to accordion sections in manuals and manual updates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/lead-paragraph';
 @import 'govuk_publishing_components/components/metadata';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
@@ -136,30 +137,12 @@ main {
   }
 
   .manual-body {
-    margin: govuk-spacing(3) 0 90px;
-
     @include govuk-media-query($from: tablet) {
       margin-top: govuk-spacing(6);
     }
 
     .section-title {
       @extend %govuk-heading-m;
-    }
-
-    .summary {
-      @include govuk-font(24);
-      margin-bottom: govuk-spacing(3);
-
-      @include govuk-media-query($from: tablet) {
-        max-width: 66.6666%;
-        margin-bottom: govuk-spacing(6);
-      }
-    }
-
-    .body-content-wrapper {
-      @include govuk-media-query($from: tablet) {
-        width: 66.6666%;
-      }
     }
 
     .footnotes {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 </head>
 <body>
   <div id="global-breadcrumb" class="header-context"></div>
-  <div id="wrapper">
+  <div id="wrapper" class="govuk-width-container">
     <% if @presented_manual.beta? %>
       <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
     <% end %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -5,56 +5,69 @@
 
 %><div class='manual-body' id="content">
   <article aria-labelledby="section-title">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: document_heading.join(" - "),
-      font_size: "m",
-      id: "section-title",
-      heading_level: 1,
-      margin_bottom: 4,
-    } %>
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: document_heading.join(" - "),
+        font_size: "m",
+        id: "section-title",
+        heading_level: 1,
+        margin_bottom: 4,
+      } %>
+    </div>
+
     <% if presented_document.summary.present? %>
-      <p class="summary"><%= presented_document.summary %></p>
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/lead_paragraph", {
+          text: presented_document.summary
+        } %>
+      </div>
     <% end %>
 
-    <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
+    <div class="govuk-grid-column-full">
+      <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
+    </div>
 
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
-        <div class='body-content-wrapper'>
+        <div class='govuk-grid-column-two-thirds'>
           <%= render 'govuk_publishing_components/components/govspeak', {} do %>
             <%= raw(presented_document.body) %>
           <% end %>
         </div>
       <% end %>
-      <div class='subsection-collection'>
-        <% presented_document.section_groups.each do | group | %>
-        <%= render 'hmrc_sections', :group => group %>
+
+      <% presented_document.section_groups.each do | group | %>
+        <div class='subsection-collection govuk-grid-column-full'>
+          <%= render 'hmrc_sections', :group => group %>
+        </div>
       <% end %>
+
+      <div class="govuk-grid-column-full">
+        <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_links(presented_document) %>
       </div>
-
-      <%= render 'govuk_publishing_components/components/previous_and_next_navigation', previous_and_next_links(presented_document) %>
-
     <% else %>
       <% if presented_document.body.present? %>
-        <%= render "govuk_publishing_components/components/govspeak", {} do
-          raw(presented_document.intro)
-        end %>
+        <div class='govuk-grid-column-two-thirds'>
+          <%= render "govuk_publishing_components/components/govspeak", {} do
+            raw(presented_document.intro)
+          end %>
 
-        <%= render "govuk_publishing_components/components/accordion", {
-          anchor_navigation: true,
-          items: presented_document.main.map do |item|
-            rendered_content = render "govuk_publishing_components/components/govspeak", {} do
-              raw(item[:content])
+          <%= render "govuk_publishing_components/components/accordion", {
+            anchor_navigation: true,
+            items: presented_document.main.map do |item|
+              rendered_content = render "govuk_publishing_components/components/govspeak", {} do
+                raw(item[:content])
+              end
+
+              {
+                heading: item[:heading],
+                content: {
+                  html: rendered_content,
+                },
+              }
             end
-
-            {
-              heading: item[:heading],
-              content: {
-                html: rendered_content,
-              },
-            }
-          end
-        } %>
+          } %>
+        </div>
       <% end %>
     <% end %>
   </article>

--- a/app/views/manuals/_manual_updates.html.erb
+++ b/app/views/manuals/_manual_updates.html.erb
@@ -1,43 +1,48 @@
 <div class='manual-body' id="content">
   <article aria-labelledby="section-title">
-    <%= render "govuk_publishing_components/components/heading", {
-      font_size: "l",
-      heading_level: 1,
-      id: "section-title",
-      margin_bottom: 4,
-      text: "Updates: #{presented_manual.title}",
-    } %>
-    <% presented_manual.change_notes.by_year.each do |year, updates_by_year| %>
+    <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/heading", {
-        text: year,
-        font_size: "l"
+        font_size: "l",
+        heading_level: 1,
+        id: "section-title",
+        margin_bottom: 4,
+        text: "Updates: #{presented_manual.title}",
       } %>
+    </div>
+    
+    <% presented_manual.change_notes.by_year.each do |year, updates_by_year| %>
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: year,
+          font_size: "l"
+        } %>
 
-      <%= render "govuk_publishing_components/components/accordion", {
-        heading_level: 3,
-        items: updates_by_year.map do |day, updated_documents|
-          accordion_content = capture do %>
-            <div class='updates-list'>
-              <% updated_documents.each do |document| %>
-                <p><%= link_to document.title, document.base_path, class: "govuk-link" %></p>
-                <% document.change_notes.each do |note| %>
-                  <%= simple_format(note) %>
+        <%= render "govuk_publishing_components/components/accordion", {
+          heading_level: 3,
+          items: updates_by_year.map do |day, updated_documents|
+            accordion_content = capture do %>
+              <div class='updates-list'>
+                <% updated_documents.each do |document| %>
+                  <p><%= link_to document.title, document.base_path, class: "govuk-link" %></p>
+                  <% document.change_notes.each do |note| %>
+                    <%= simple_format(note) %>
+                  <% end %>
+                  <br/>
                 <% end %>
-                <br/>
-              <% end %>
-            </div>
-          <% end
+              </div>
+            <% end
 
-          {
-            heading: {
-              text: sanitize("#{marked_up_date(day)} <span class=\"visuallyhidden\">published amendments</span>"),
-            },
-            content: {
-              html: accordion_content
+            {
+              heading: {
+                text: sanitize("#{marked_up_date(day)} <span class=\"visuallyhidden\">published amendments</span>"),
+              },
+              content: {
+                html: accordion_content
+              }
             }
-          }
-        end
-      } %>
+          end
+        } %>
+      </div>
     <% end %>
   </article>
 </div>

--- a/app/views/manuals/show.html.erb
+++ b/app/views/manuals/show.html.erb
@@ -23,10 +23,13 @@
     presented_document: presented_document
   )
 %>
-<%=
-  render(
-    'manual_section',
-    presented_manual: presented_manual,
-    presented_document: presented_document
-  )
-%>
+
+<div class="govuk-grid-row">
+  <%=
+    render(
+      'manual_section',
+      presented_manual: presented_manual,
+      presented_document: presented_document
+    )
+  %>
+</div>

--- a/app/views/manuals/updates.html.erb
+++ b/app/views/manuals/updates.html.erb
@@ -22,4 +22,6 @@
     presented_manual: presented_manual
   )
 %>
-<%= render 'manual_updates', presented_manual: presented_manual %>
+<div class="govuk-grid-row">
+  <%= render 'manual_updates', presented_manual: presented_manual %>
+</div>


### PR DESCRIPTION
## What
Sets a two thirds limit on desktop for manual body content where accordions are rendered.

Additionally, this PR does some spring cleaning adjacent to this view:
- Adds a `govuk-width-container` class to the `id="wrapper"` content container div
- Replaces the lead paragraph on manuals with the [lead paragraph component](https://components.publishing.service.gov.uk/component-guide/lead_paragraph)

## Why
This is in response to feedback from department publishers that accordions are now very long which isn't a good experience for magnification users.

[Card](https://trello.com/c/wfX1mzXP/675-fix-accordion-column-text-width)

### Pages developed against
- https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages
- https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19/updates
- https://www.gov.uk/hmrc-internal-manuals/holding-and-movements-assurance-guidance/hmag60320

## Visual changes
### Before - manual
![Screenshot 2021-03-09 at 15 12 22](https://user-images.githubusercontent.com/64783893/110496843-cecbcf80-80ed-11eb-8f0d-f0653b203868.png)

### Before - updates
![Screenshot 2021-03-09 at 15 05 27](https://user-images.githubusercontent.com/64783893/110496867-d3908380-80ed-11eb-833d-5364cf3f3302.png)

### After - manual
![Screenshot 2021-03-09 at 15 16 13](https://user-images.githubusercontent.com/64783893/110496880-d8553780-80ed-11eb-848a-91aac33724b3.png)

### After - updates
![Screenshot 2021-03-09 at 18 10 55](https://user-images.githubusercontent.com/64783893/110518190-b8c90980-8103-11eb-9090-8baf381c8d35.png)

