### PR TITLE
Add lead paragraph component to contents page view

### DIFF
--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -1,6 +1,10 @@
 <article aria-labelledby="manual-title" id="content">
   <div class='manual-body'>
-    <% if presented_manual.summary.present? %><p class='summary'><%= presented_manual.summary %></p><% end %>
+    <% if presented_manual.summary.present? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: presented_manual.summary
+      } %>
+    <% end %>
 
     <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
 


### PR DESCRIPTION
## What
Fixes a bug on manual contents pages ([Example](https://www.gov.uk/guidance/style-guide)) where the lead paragraph is too small by replacing it with the [lead paragraph component](https://components.publishing.service.gov.uk/component-guide/lead_paragraph).

## Why
This bug was introduced accidentally in https://github.com/alphagov/manuals-frontend/pull/1085 when the `summary` class was removed but this instance of it was missed.

## Visual changes
### Before
![Screenshot 2021-03-16 at 16 36 57](https://user-images.githubusercontent.com/64783893/111346598-495c9800-8676-11eb-9b61-be48038931d2.png)

### After
![Screenshot 2021-03-16 at 16 36 41](https://user-images.githubusercontent.com/64783893/111346578-43ff4d80-8676-11eb-9bb4-78e543b82d58.png)