### PR TITLE
Handle gone status

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  rescue_from GdsApi::HTTPForbidden, with: :error_403
-  rescue_from ActionView::MissingTemplate, with: :error_406
-  rescue_from ActionController::UnknownFormat, with: :error_406
-
   before_action :slimmer_headers
 
   if ENV["BASIC_AUTH_USERNAME"]
@@ -20,14 +16,6 @@ class ApplicationController < ActionController::Base
   end
 
 private
-
-  def error_403
-    render status: :forbidden, plain: "403 forbidden"
-  end
-
-  def error_406
-    render plain: "Not acceptable", status: :not_acceptable
-  end
 
   def slimmer_headers
     slimmer_template "core_layout"

--- a/app/repositories/document_repository.rb
+++ b/app/repositories/document_repository.rb
@@ -16,8 +16,6 @@ private
 
   def fetch_content_item(base_path)
     GdsApi.content_store.content_item(base_path)
-  rescue GdsApi::ContentStore::ItemNotFound
-    nil
   end
 
   def extract_parent_base_path_from_document(document)

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -175,22 +175,23 @@ feature "Viewing manuals and sections" do
     expect(page.status_code).to eq(404)
   end
 
-  scenario "visiting a withdrawn section" do
+  scenario "visiting a redirected section" do
     stub_fake_manual base_path: "/guidance/my-manual-about-burritos"
     stub_redirected_section "my-manual-about-burritos", "rolls-are-better"
     visit_manual_section "my-manual-about-burritos", "rolls-are-better"
     expect(current_url).to eq("http://www.dev.gov.uk/guidance/my-manual-about-burritos")
   end
 
-  scenario "visiting a withdrawn manual's updates" do
-    slug = "/guidance/a-withdrawn-manual"
-    stub_withdrawn_manual(slug)
+  scenario "visiting a gone page" do
+    base_path = "/hmrc-internal-manuals/admin-law-manual/gone-page"
+    stub_hmrc_manual("admin-law-manual")
+    stub_content_store_has_gone_item(base_path)
 
-    visit "#{slug}/updates"
+    visit base_path
     expect(page.status_code).to eq(410)
   end
 
-  scenario "visiting access limited manual returns 403 forbidden" do
+  scenario "visiting access limited manual" do
     slug = "guidance/an-access-limited-manual"
     stub_request(:get, "#{Plek.find('content-store')}/content/#{slug}")
       .to_return(status: 403, headers: {})

--- a/spec/support/manual_helpers.rb
+++ b/spec/support/manual_helpers.rb
@@ -322,16 +322,6 @@ module ManualHelpers
     }
     stub_content_store_has_item("/guidance/#{manual_id}/#{section_id}", document)
   end
-
-  def stub_withdrawn_manual(base_path)
-    gone_json = {
-      base_path: base_path,
-      format: "gone",
-      phase: "live",
-    }
-
-    stub_content_store_has_item(base_path, gone_json)
-  end
 end
 
 RSpec.configuration.include ManualHelpers


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/govuk/issues/1752513075/?environment=production&project=202235&query=is%3Aignored

Previously the code would raise an error if `document_from_repository`
returned a document that had a status of 'Gone'. This was raised as
[HTTPGone][1] from gds-api-adapters as a result of receiving a 410 from
content-store.

Now 'Gone' pages and their corresponding exception are rescued and
handled by returning a 410 status code which in turn renders a [generic
410 error page][2].

I've also refactored the error handling logic as part of this work
which:

* moves all this behaviour to the manuals controller
* follows the pattern in [government-frontend][3]

[1]: https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/exceptions.rb#L90-L91
[2]: https://github.com/alphagov/static/blob/master/app/views/root/410.html.erb
[3]: https://github.com/alphagov/government-frontend/blob/e5c0c97dc614b9513b82e106074e9293826498a4/app/controllers/content_items_controller.rb#L2-L10

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
