### PR TITLE
Remove brexit callout from HMRC manuals

### DIFF
--- a/app/views/manuals/_hmrc_callout.html.erb
+++ b/app/views/manuals/_hmrc_callout.html.erb
@@ -1,7 +1,0 @@
-<% if presented_manual.hmrc? %>
-  <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <div role="note" aria-label="Information" class="application-notice help-notice">
-      <p>You should check the other <a href="/government/organisations/hm-revenue-customs/services-information">guidance available on GOV.UK from HMRC</a> as Brexit updates to those pages are being prioritised before manuals.</p>
-    </div>
-  <% end %>
-<% end %>

--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -5,9 +5,6 @@
         text: presented_manual.summary
       } %>
     <% end %>
-
-    <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
-
     <% if presented_manual.body.present? %>
       <%= render 'govuk_publishing_components/components/govspeak', {} do %>
         <%= raw(presented_manual.body) %>

--- a/app/views/manuals/_manual_section.html.erb
+++ b/app/views/manuals/_manual_section.html.erb
@@ -22,11 +22,6 @@
         } %>
       </div>
     <% end %>
-
-    <div class="govuk-grid-column-full">
-      <%= render partial: "hmrc_callout", locals: { presented_manual: presented_manual } %>
-    </div>
-
     <% if presented_manual.hmrc? %>
       <% if presented_document.body.present? %>
         <div class='govuk-grid-column-two-thirds'>

--- a/spec/features/viewing_a_manual_spec.rb
+++ b/spec/features/viewing_a_manual_spec.rb
@@ -39,14 +39,12 @@ feature "Viewing manuals and sections" do
   scenario "viewing a non-HMRC manual" do
     stub_fake_manual
     visit_manual "my-manual-about-burritos"
-    expect(page).not_to have_text("There is something afoot")
     expect(page).not_to have_selector(".gem-c-phase-banner")
   end
 
   scenario "viewing an HMRC manual" do
     stub_hmrc_manual
     visit_hmrc_manual "inheritance-tax-manual"
-    expect(page).to have_css(".gem-c-govspeak", text: "You should check the other guidance available on GOV.UK from HMRC as Brexit updates to those pages are being prioritised before manuals.")
     expect(page).to have_selector(".gem-c-phase-banner")
   end
 


### PR DESCRIPTION
### What

Remove Brexit callout from HMRC manuals. This PR reverts https://github.com/alphagov/manuals-frontend/commit/3cd22d7dd65a787283bc766736a4d82839638183

<table>
<tr><td>Before (with callout) </td><td>After (without callout)</td></tr>
 <tr>
 <td> 
<img width="899" alt="Screenshot 2021-04-28 at 10 36 07" src="https://user-images.githubusercontent.com/17908089/116383194-88057680-a80e-11eb-91a4-3bde4541e1ab.png">
</td>
<td>
<img width="899" alt="Screenshot 2021-04-28 at 10 36 50" src="https://user-images.githubusercontent.com/17908089/116383718-06faaf00-a80f-11eb-8075-7c384fe6ecef.png">

</td>
</tr> 
</table>

### No callouts on HMRC manuals:

- https://manuals-fron-remove-hmr-mlvyla.herokuapp.com/hmrc-internal-manuals/international-manual
- https://manuals-fron-remove-hmr-mlvyla.herokuapp.com/hmrc-internal-manuals/international-manual/intm120000
- https://manuals-fron-remove-hmr-mlvyla.herokuapp.com/hmrc-internal-manuals/international-manual/intm120010

Trello: https://trello.com/c/G9onGAh5/1478-remove-hmrc-manuals-callout-banner

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
