### PR TITLE
Apply new link styles to manuals

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,13 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/accordion';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
@@ -125,12 +127,19 @@ main {
 
         .subsection-title-text {
           @include govuk-typography-weight-bold;
+          @include govuk-link-decoration;
           display: block;
         }
 
         .subsection-summary {
           color: $govuk-text-colour;
           display: block;
+        }
+
+        &:hover {
+          .subsection-title-text {
+            @include govuk-link-hover-decoration;
+          }
         }
       }
     }

--- a/app/views/manuals/_hmrc_sections.html.erb
+++ b/app/views/manuals/_hmrc_sections.html.erb
@@ -4,7 +4,7 @@
 <ol class='section-list hmrc'>
 <% group.sections.each do | section | %>
   <li>
-    <%= link_to section.path do %>
+    <%= link_to section.path, class: "govuk-link" do %>
     <div class='title-wrap'>
       <% if section.section_id %>
         <div class='subsection-id'><%= section.section_id %></div>

--- a/app/views/manuals/_manual.html.erb
+++ b/app/views/manuals/_manual.html.erb
@@ -16,16 +16,18 @@
         <%= render 'hmrc_sections', group: group %>
       </div>
       <% else %>
-        <ol class='section-list'>
-        <% group.sections.each do | section | %>
-          <li>
-          <%= link_to section.path, class: "#{section.section_id.present? ? 'subsection-with-id' : ''}" do %>
-              <span class='subsection-title-text'><%= section.title %></span>
-              <span class='subsection-summary'><%= section.summary %></span>
-          <% end %>
-          </li>
-        <% end %>
-        </ol>
+        <%= render "govuk_publishing_components/components/document_list", {
+          items: group.sections.map do | section |
+            {
+              link: {
+                text: section.title,
+                path: section.path,
+                description: section.summary,
+                full_size_description: true,
+              }
+            }
+          end
+        } %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
## What
Apply the new link styles, from the latest release of GOV.UK Frontend, to this app.

As part of this, this PR also replaces the section lists seen on manuals index pages ([example](https://www.gov.uk/guidance/academies-financial-handbook)) with the [document list component](https://components.publishing.service.gov.uk/component-guide/document_list).

## Why
Part of an ongoing effort by the GOV.UK Frontend community and GOV.UK Accessibility team to ensure that we are using the latest link styles across all our apps to ensure that users benefit from improved link visibility.

## Pages tested
- https://www.gov.uk/guidance/academies-financial-handbook
- https://www.gov.uk/hmrc-internal-manuals/pensions-tax-manual
- https://www.gov.uk/hmrc-internal-manuals/trusts-settlements-and-estates-manual/tsem9900
- https://www.gov.uk/guidance/national-planning-policy-framework/15-conserving-and-enhancing-the-natural-environment
- https://www.gov.uk/guidance/drivers-hours-goods-vehicles/updates

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-07-12 at 17 48 05](https://user-images.githubusercontent.com/64783893/125326974-89890a00-e33a-11eb-8cfb-6c9c1e7729a2.png) | ![Screenshot 2021-07-12 at 17 47 49](https://user-images.githubusercontent.com/64783893/125327015-91e14500-e33a-11eb-8c05-d6301f584400.png) |
| ![Screenshot 2021-07-12 at 17 48 28](https://user-images.githubusercontent.com/64783893/125327079-a45b7e80-e33a-11eb-9331-33950119f8ca.png) | ![Screenshot 2021-07-12 at 17 48 18](https://user-images.githubusercontent.com/64783893/125327103-aa515f80-e33a-11eb-9c0d-f24fdb6cb8d4.png) |