### PR TITLE
Swap to `gem_layout`

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,8 @@
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/accordion';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
@@ -151,7 +150,9 @@ main {
     }
 
     .section-title {
-      @extend %govuk-heading-m;
+      @include govuk-text-colour;
+      @include govuk-font($size: 24, $weight: bold);
+      @include govuk-responsive-margin(4, "bottom");
     }
 
     .footnotes {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
 private
 
   def slimmer_headers
-    slimmer_template "core_layout"
+    slimmer_template :gem_layout
     set_slimmer_headers(remove_search: true)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,6 @@
         </div>
       </div>
     </main>
-    <%= render 'govuk_publishing_components/components/feedback' %>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### What

Update `manuals-frontend` to use the Design System-based page layout

### Why

Major benefits include performance improvements, accessibility improvements, and consistency with other applications.

### Visual changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![www gov uk_guidance_content-design](https://user-images.githubusercontent.com/788096/128032490-81df97d7-9ea7-4670-99f5-e1411625c75d.png)

</td><td valign="top">

![manuals-fron-swap-to-ge-qeotdx herokuapp com_guidance_content-design](https://user-images.githubusercontent.com/788096/128032529-4fb605bc-2e96-4fd0-8a69-4bc72898c8d2.png)


</td></tr>
</table>



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
