### PR TITLE
Remove padding on section-list

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,6 +92,7 @@ main {
 
   .section-list {
     margin-top: govuk-spacing(6);
+    padding: 0;
 
     @include govuk-media-query($from: tablet) {
       margin-top: govuk-spacing(9);


### PR DESCRIPTION
The section-list elements were reliant on a CSS reset for zero padding. This reset CSS was dropped when swapping from `core_layout` to `gem_layout` in #1173 but this regression was missed while doing the manual review.

Note: This issue is not yet in production but can be seen in integration.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![www integration publishing service gov uk_hmrc-internal-manuals_pensions-tax-manual_ptm010000](https://user-images.githubusercontent.com/788096/130420758-d71e0da0-94dc-4486-a189-4157a6067833.png)


</td><td valign="top">

![dev gov uk_hmrc-internal-manuals_pensions-tax-manual_ptm010000](https://user-images.githubusercontent.com/788096/130420845-1010f037-626a-4e5d-b066-685f1fc94671.png)


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
