### PR TITLE
Add listen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "uglifier"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "listen"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
     launchy (2.5.0)
       addressable (~> 2.7)
     link_header (0.0.8)
+    listen (3.7.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
@@ -231,6 +234,9 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.2)
     rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -370,6 +376,7 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_test
   launchy
+  listen
   plek
   pry-byebug
   rails (= 6.1.4.1)


### PR DESCRIPTION
The listen gem is now required to run apps in development due to an 
evented file watcher being added in our rails upgrades.

This is to prevent the error:
```
`require': cannot load such file -- listen (LoadError)
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
