### PR TITLE
Improve Docker image for GOV.UK EKS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+Jenkinsfile
+README.md
+docs
+log
+spec
+tmp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Build and publish to ECR
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+
+jobs:
+  build-publish-image-to-ecr:
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
As part of the new GOV.UK EKS, the Dockerfile is improved to match
other new Dockerfiles, e.g. [frontend Dockerfile](https://github.com/alphagov/frontend/pull/3005)

In addition:
1. Puma is used instead of unicorm as web server
2. GitHub Actions workflow is added to push image to ECR on merge to main

Ref:
1. [trello card](https://trello.com/c/dP4vi19p/835-package-manuals-frontend-for-migration)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
