### PR TITLE
Remove jQuery from manuals-frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,6 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/print-link
 
-jQuery(function ($) {
-  'use strict'
+if (GOVUK.primaryLinks) {
   GOVUK.primaryLinks.init('.primary-item')
-})
+}


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove jQuery from this application.

- only jQuery was this document.ready equivalent for primaryLinks
- replacing this is possible but slightly complicated by browser compatibility issues
- so maybe we could remove it entirely
- we've already removed document.ready successfully elsewhere on GOV.UK without a direct replacement, and testing this here it seems to work as well
- primaryLinks is still initialised and runs successfully

## Why
We're removing jQuery from GOV.UK.

## Visual changes
None.
