### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bin/bundle
 
 FROM $base_image
 
-ENV RAILS_ENV=production GOVUK_APP_NAME=manuals-frontend
+ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=manuals-frontend
 
 RUN apt-get update -qy && \
     apt-get upgrade -y && \

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
